### PR TITLE
include bin js in npm's bin

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,5 +27,8 @@
   "devDependencies": {
     "mocha": "^5.2.0",
     "standard": "^12.0.1"
+  },
+  "bin": {
+    "barnard59": "bin/barnard59.js"
   }
 }


### PR DESCRIPTION
Trivial change but I thought it would be useful to actually have the option to run the CLI directly

```
npm run barnard59 run xyzzy.json
```