### PR TITLE
update examples to use latest loader syntax

### DIFF
--- a/examples/fetch-json-to-ntriples.json
+++ b/examples/fetch-json-to-ntriples.json
@@ -9,9 +9,6 @@
     "code:link": {
       "@type": "@id"
     },
-    "code:type": {
-      "@type": "@id"
-    },
     "operation": {
       "@type": "@id"
     },
@@ -56,7 +53,7 @@
       "@id": "fetch",
       "operation": {
         "code:link": "file:../node_modules/barnard59-base#fetch.json",
-        "code:type": "code:ecmaScript"
+        "@type": "code:ecmaScript"
       },
       "arguments": [{
         "@value": "${url}",
@@ -66,7 +63,7 @@
       "@id": "jsonldStructure",
       "operation": {
         "code:link": "file:../node_modules/barnard59-base#map",
-        "code:type": "code:ecmaScript"
+        "@type": "code:ecmaScript"
       },
       "arguments": [{
         "@value": "json => { return { '@context': JSON.parse(this.variables.get('context')), '@id': this.variables.get('url'), date: json.currentDateTime } }",
@@ -76,13 +73,13 @@
       "@id": "parse",
       "operation": {
         "code:link": "file:../node_modules/barnard59-formats#jsonld.parse.object",
-        "code:type": "code:ecmaScript"
+        "@type": "code:ecmaScript"
       }
     }, {
       "@id": "serialize",
       "operation": {
         "code:link": "file:../node_modules/barnard59-formats#ntriples.serialize",
-        "code:type": "code:ecmaScript"
+        "@type": "code:ecmaScript"
       }
     }]
   }]

--- a/examples/fetch-json-to-ntriples.ttl
+++ b/examples/fetch-json-to-ntriples.ttl
@@ -33,25 +33,25 @@
 <fetch> a p:Step ;
   p:operation [
     code:link <file:../node_modules/barnard59-base#fetch.json> ;
-    code:type code:ecmaScript
+    a code:ecmaScript
   ];
   p:arguments ("${url}"^^code:ecmaScriptTemplateLiteral) .
 
 <jsonldStructure> a p:Step ;
   p:operation [
     code:link <file:../node_modules/barnard59-base#map> ;
-    code:type code:ecmaScript
+    a code:ecmaScript
   ];
   p:arguments ("json => { return { '@context': JSON.parse(this.variables.get('context')), '@id': this.variables.get('url'), date: json.currentDateTime } }"^^code:ecmaScript) .
 
 <parse> a p:Step ;
   p:operation [
     code:link <file:../node_modules/barnard59-formats#jsonld.parse.object> ;
-    code:type code:ecmaScript
+    a code:ecmaScript
   ] .
 
 <serialize> a p:Step ;
   p:operation [
     code:link <file:../node_modules/barnard59-formats#ntriples.serialize> ;
-    code:type code:ecmaScript
+    a code:ecmaScript
   ] .

--- a/examples/parse-csvw.ttl
+++ b/examples/parse-csvw.ttl
@@ -20,7 +20,7 @@
 <readFile> a p:Step;
   p:operation [
     code:link <node:fs#createReadStream>;
-    code:type code:ecmaScript
+    a code:ecmaScript
   ];
   p:arguments ("${filename}"^^code:ecmaScriptTemplateLiteral).
 
@@ -28,34 +28,31 @@
 <parse> a p:Step;
   p:operation [
     code:link <node:barnard59-formats#csvw.parse>;
-    code:type code:ecmaScript
+    a code:ecmaScript
   ];
-  p:arguments ([
-    code:link <parseMetadata>;
-    code:type p:ObjectPipeline
-  ]).
+  p:arguments ( <parseMetadata> ).
 
 <serialize> a p:Step;
   p:operation [
     code:link <file:../node_modules/barnard59-formats#ntriples.serialize> ;
-    code:type code:ecmaScript
+    a code:ecmaScript
   ].
 
 
-<parseMetadata> a p:Pipeline;
+<parseMetadata> a p:ObjectPipeline;
   p:steps [
-    p:stepList ( <readMetadata> <parseMetadata> )
+    p:stepList ( <readMetadata> <parseMetadataStep> )
   ].
 
 <readMetadata> a p:Step;
   p:operation [
     code:link <node:fs#createReadStream>;
-    code:type code:ecmaScript
+    a code:ecmaScript
   ];
   p:arguments ("${metadata}"^^code:ecmaScriptTemplateLiteral).
 
-<parseMetadata> a p:Step;
+<parseMetadataStep> a p:Step;
   p:operation [
     code:link <node:barnard59-formats#jsonld.parse>;
-    code:type code:ecmaScript
+    a code:ecmaScript
   ].


### PR DESCRIPTION
- rdf:type replaces code:type
- child pipelines references directly as resources