### PR TITLE
don't filter out console logs

### DIFF
--- a/lib/TextLogStream.js
+++ b/lib/TextLogStream.js
@@ -6,9 +6,7 @@ class TextLogStream extends Transform {
   }
 
   _transform (chunk, e, next) {
-    if (chunk.name) {
-      this.push(`${chunk.level} ${chunk.stack[0]} ${chunk.message}\r\n`)
-    }
+    this.push(`${chunk.level} ${chunk.stack[0]} ${chunk.message}\r\n`)
     next()
   }
 }


### PR DESCRIPTION
Removed the condition in log writer.

The condition is actually annoying because any custom logs in pipeline code gets ignored by default. 