### PR TITLE
exit with code 1 on pipeline error, fixed tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - "6"
   - "8"
   - "10"
 addons:
@@ -11,7 +10,3 @@ addons:
       - g++-4.9
 before_install:
   - export CXX="g++-4.9" CC="gcc-4.9"
-script:
-  - node bin/barnard59.js run examples/fetch-json-to-ntriples.json --pipeline http://example.org/pipeline/cet
-  - node bin/barnard59.js run examples/fetch-json-to-ntriples.ttl --format text/turtle --pipeline http://example.org/pipeline/utc
-  - node bin/barnard59.js run examples/parse-csvw.ttl --format=text/turtle --pipeline=http://example.org/pipeline/parseCsvw

--- a/bin/barnard59.js
+++ b/bin/barnard59.js
@@ -93,7 +93,10 @@ program
           }
         }
 
-        stream.on('error', err => console.error(err))
+        stream.on('error', err => {
+          console.error(err)
+          process.exit(1)
+        })
 
         stream.pipe(createOutputStream(output))
 
@@ -102,7 +105,10 @@ program
         }
 
         return p.run(stream)
-      }).catch(err => console.error(err))
+      }).catch(err => {
+        console.error(err)
+        process.exit(1)
+      })
   })
 
 program.parse(process.argv)

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Barnard59 Linked Data pipelines",
   "main": "index.js",
   "scripts": {
-    "test": "standard && mocha"
+    "test": "standard && jest"
   },
   "repository": {
     "type": "git",
@@ -30,7 +30,8 @@
     "readable-stream": "^3.1.1"
   },
   "devDependencies": {
-    "mocha": "^5.2.0",
+    "jest": "^24.9.0",
+    "shelljs": "^0.8.3",
     "standard": "^12.0.1"
   },
   "bin": {

--- a/test/barnard59.test.js
+++ b/test/barnard59.test.js
@@ -1,0 +1,48 @@
+/* global describe, expect, it */
+
+const { resolve } = require('path')
+const shell = require('shelljs')
+
+const barnard59 = resolve(__dirname, '../bin/barnard59.js')
+
+describe('barnard59', () => {
+  describe('run', () => {
+    it('should exit with error code 1 when an error in the pipeline occurs', () => {
+      const pipelineFile = resolve(__dirname, 'support/error.ttl')
+      const command = `${barnard59} run --format=text/turtle --pipeline=http://example.org/pipeline ${pipelineFile}`
+
+      const result = shell.exec(command, { silent: true })
+
+      expect(result.code).toBe(1)
+    })
+  })
+
+  describe('examples', () => {
+    it('should run the fetch-json-to-ntriples.json example without error', () => {
+      const pipelineFile = resolve(__dirname, '../examples/fetch-json-to-ntriples.json')
+      const command = `${barnard59} run --pipeline=http://example.org/pipeline/cet ${pipelineFile}`
+
+      const result = shell.exec(command, { silent: true })
+
+      expect(result.code).toBe(0)
+    })
+
+    it('should run the fetch-json-to-ntriples.ttl example without error', () => {
+      const pipelineFile = resolve(__dirname, '../examples/fetch-json-to-ntriples.ttl')
+      const command = `${barnard59} run --format=text/turtle --pipeline=http://example.org/pipeline/utc ${pipelineFile}`
+
+      const result = shell.exec(command, { silent: true })
+
+      expect(result.code).toBe(0)
+    })
+
+    it('should run the parse-csvw.ttl example without error', () => {
+      const pipelineFile = resolve(__dirname, '../examples/parse-csvw.ttl')
+      const command = `${barnard59} run --format=text/turtle --pipeline=http://example.org/pipeline/parseCsvw ${pipelineFile}`
+
+      const result = shell.exec(command, { silent: true })
+
+      expect(result.code).toBe(0)
+    })
+  })
+})

--- a/test/support/error.js
+++ b/test/support/error.js
@@ -1,0 +1,13 @@
+const { Readable } = require('readable-stream')
+
+function error () {
+  const stream = new Readable({
+    read: () => {
+      stream.emit('error', new Error('test'))
+    }
+  })
+
+  return stream
+}
+
+module.exports = error

--- a/test/support/error.ttl
+++ b/test/support/error.ttl
@@ -1,0 +1,15 @@
+@base <http://example.org/> .
+@prefix code: <https://code.described.at/> .
+@prefix p: <https://pipeline.described.at/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+
+<pipeline> a p:Pipeline, p:Readable;
+  p:steps [
+    p:stepList (<error>)
+  ].
+
+<error> a p:Step;
+  code:implementedBy [
+    code:link <file:error.js>;
+    a code:EcmaScript
+  ].


### PR DESCRIPTION
- exit with code 1 in the CLI tool when the pipeline throws an error
- initial jest test setup + test for exit code 1 on pipeline error
- removed Node v6 from the Travis config (was broken because of the usage of new JS features support by v8+)
- moved examples tests from Travis config to jest test