### PR TITLE
removed formats, protocols and shell dependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,4 @@
 const base = require('barnard59-base')
 const core = require('barnard59-core')
-const formats = require('barnard59-formats')
-const protocols = require('barnard59-protocols')
 
-module.exports = Object.assign({}, core, base, formats, protocols)
+module.exports = Object.assign({}, core, base)

--- a/package.json
+++ b/package.json
@@ -21,15 +21,13 @@
     "@rdfjs/namespace": "^1.0.0",
     "barnard59-base": "0.0.1",
     "barnard59-core": "0.0.3",
-    "barnard59-formats": "0.0.3",
-    "barnard59-protocols": "0.0.1",
-    "barnard59-shell": "0.0.1",
     "clownface": "^0.11.0",
     "commander": "^2.19.0",
     "rdf-ext": "^1.1.2",
     "readable-stream": "^3.1.1"
   },
   "devDependencies": {
+    "barnard59-formats": "0.0.4",
     "jest": "^24.9.0",
     "shelljs": "^0.8.3",
     "standard": "^12.0.1"


### PR DESCRIPTION
This PR removes the formats, protocols and shell dependencies. Each pipeline project should install the required dependencies manually. That should keep the projects smaller, because we get more and more packages to support formats and protocols.