### PR TITLE
Multi root error

### DIFF
--- a/.changeset/angry-dolphins-sort.md
+++ b/.changeset/angry-dolphins-sort.md
@@ -1,0 +1,5 @@
+---
+"barnard59": patch
+---
+
+Improve error output when multiple pipelines are found (fixes #160)

--- a/packages/cli/bin/barnard59.js
+++ b/packages/cli/bin/barnard59.js
@@ -31,10 +31,11 @@ const onError = async err => {
   process.off('SIGTERM', onError)
 
   if (err) {
-    // eslint-disable-next-line no-console
     if (err.skipTrace) {
+      // eslint-disable-next-line no-console
       console.log(err.message)
     } else {
+      // eslint-disable-next-line no-console
       console.log(err)
     }
   }

--- a/packages/cli/bin/barnard59.js
+++ b/packages/cli/bin/barnard59.js
@@ -32,7 +32,11 @@ const onError = async err => {
 
   if (err) {
     // eslint-disable-next-line no-console
-    console.log(err)
+    if (err.skipTrace) {
+      console.log(err.message)
+    } else {
+      console.log(err)
+    }
   }
   await sdk.shutdown()
   process.exit(1)

--- a/packages/cli/bin/barnard59.js
+++ b/packages/cli/bin/barnard59.js
@@ -11,6 +11,7 @@ import { BatchSpanProcessor } from '@opentelemetry/tracing'
 
 import { Command } from 'commander'
 import * as monitoringOptions from '../lib/cli/monitoringOptions.js'
+import { MultipleRootsError } from '../findPipeline.js'
 
 const sdk = new NodeSDK({
   // Automatic detection is disabled, see comment below
@@ -31,9 +32,10 @@ const onError = async err => {
   process.off('SIGTERM', onError)
 
   if (err) {
-    if (err.skipTrace) {
+    if (err instanceof MultipleRootsError) {
+      const alternatives = err.alternatives.map(x => `\n\t--pipeline ${x}`).join('')
       // eslint-disable-next-line no-console
-      console.log(err.message)
+      console.log(`Multiple root pipelines found. Try one of these:${alternatives}`)
     } else {
       // eslint-disable-next-line no-console
       console.log(err)

--- a/packages/cli/findPipeline.js
+++ b/packages/cli/findPipeline.js
@@ -1,6 +1,14 @@
 import clownface from 'clownface'
 import ns from './lib/namespaces.js'
 
+export class MultipleRootsError extends Error {
+  constructor(alternatives) {
+    super('Multiple root pipelines found')
+    this.name = 'MultipleRootsError'
+    this.alternatives = alternatives
+  }
+}
+
 function findPipeline(dataset, iri) {
   let ptr = clownface({ dataset })
 
@@ -19,10 +27,7 @@ function findPipeline(dataset, iri) {
   }
 
   if (ptr.terms.length > 1) {
-    const alternatives = ptr.values.map(x => `\n\t--pipeline ${x}`).join('')
-    const error = new Error(`Multiple root pipelines found. Try one of these:${alternatives}`)
-    error.skipTrace = true
-    throw error
+    throw new MultipleRootsError(ptr.values)
   }
 
   return ptr

--- a/packages/cli/findPipeline.js
+++ b/packages/cli/findPipeline.js
@@ -19,7 +19,10 @@ function findPipeline(dataset, iri) {
   }
 
   if (ptr.terms.length > 1) {
-    throw new Error('Multiple root pipelines found.')
+    const alternatives = ptr.values.map(x => `\n\t--pipeline ${x}`).join('')
+    const error = new Error(`Multiple root pipelines found. Try one of these:${alternatives}`)
+    error.skipTrace = true
+    throw error
   }
 
   return ptr

--- a/packages/cli/test/barnard59.test.js
+++ b/packages/cli/test/barnard59.test.js
@@ -11,6 +11,15 @@ describe('barnard59', function () {
   this.timeout(10000)
 
   describe('run', () => {
+    it('should suggest alternatives when multiple root pipelines exist', () => {
+      const pipelineFile = filenamePipelineDefinition('multiple-root')
+      const command = `${barnard59} run ${pipelineFile}`
+
+      const result = shell.exec(command, { silent: true, cwd })
+
+      strictEqual(result.code, 1)
+      expect(result.stdout).to.equal('Multiple root pipelines found. Try one of these:\n\t--pipeline http://example.org/pipeline/p1\n\t--pipeline http://example.org/pipeline/p2\n')
+    })
     it('should exit with error code 0 if there are no error while processing the pipeline', () => {
       const pipelineFile = filenamePipelineDefinition('simple')
       const command = `${barnard59} run --pipeline=http://example.org/pipeline/ ${pipelineFile}`

--- a/packages/cli/test/support/definitions/multiple-root.ttl
+++ b/packages/cli/test/support/definitions/multiple-root.ttl
@@ -1,0 +1,6 @@
+@base <http://example.org/pipeline/>.
+@prefix p: <https://pipeline.described.at/>.
+
+<p1> a p:Pipeline.
+<p2> a p:Pipeline.
+


### PR DESCRIPTION
It should work but there's room for improvement. 

A more engineered solution may avoid the dynamic field `skipTrace` and rely on a more specific error class, as suggested for example [here](https://javascript.info/custom-errors) (we should put such a class definition in some core module, where exactly?).

I also would like to improve naming. Whether we keep the dynamic field or we declare some custom error type, the name should describe the kind of error (caused by the user, hence not a system fault) and not how we would like it to be handled (which is not a concern of the code throwing it)