### PR TITLE
feat: overriding property shape terms

### DIFF
--- a/.changeset/purple-forks-give.md
+++ b/.changeset/purple-forks-give.md
@@ -1,0 +1,5 @@
+---
+"barnard59-rdf": patch
+---
+
+`cube.js#toCubeShape`: add argument propertyShapeId which creates dimension Property Shape identifiers

--- a/.changeset/tidy-roses-walk.md
+++ b/.changeset/tidy-roses-walk.md
@@ -1,0 +1,5 @@
+---
+"barnard59-rdf": patch
+---
+
+Remove direct usages of clownface

--- a/packages/rdf/lib/cube/buildCubeShape/Cube.js
+++ b/packages/rdf/lib/cube/buildCubeShape/Cube.js
@@ -5,12 +5,13 @@ import * as ns from '../../namespaces.js'
 import Dimension from './Dimension.js'
 
 class Cube {
-  constructor({ metadata, observationSet, shape, term }) {
+  constructor({ metadata, observationSet, shape, term, propertyShapeId }) {
     this.metadata = metadata
     this.observationSet = observationSet
     this.shape = shape
     this.term = term
     this.dimensions = rdf.termMap()
+    this.propertyShapeId = propertyShapeId
   }
 
   dimension({ predicate, object }) {
@@ -22,7 +23,7 @@ class Cube {
         .out(ns.sh.property)
         .has(ns.sh.path, predicate)
 
-      dimension = new Dimension({ metadata, predicate, object })
+      dimension = new Dimension({ metadata, predicate, object, shapeId: this.propertyShapeId })
 
       this.dimensions.set(predicate, dimension)
     }
@@ -54,7 +55,7 @@ class Cube {
       .addOut(ns.sh.closed, true)
 
     for (const dimension of this.dimensions.values()) {
-      addAll(shapeDataset, dimension.toDataset({ shape: this.shape }))
+      addAll(shapeDataset, dimension.toDataset({ cube: this, shape: this.shape }))
     }
     const setGraph = quad => rdf.quad(quad.subject, quad.predicate, quad.object, shapeGraph)
 

--- a/packages/rdf/lib/cube/buildCubeShape/Cube.js
+++ b/packages/rdf/lib/cube/buildCubeShape/Cube.js
@@ -1,4 +1,3 @@
-import clownface from 'clownface'
 import rdf from '@zazuko/env'
 import addAll from 'rdf-dataset-ext/addAll.js'
 import cbdCopy from '../../cbdCopy.js'
@@ -38,19 +37,19 @@ class Cube {
   toDataset({ shapeGraph } = { shapeGraph: undefined }) {
     const dataset = rdf.dataset()
 
-    const cube = clownface({ dataset, term: this.term })
+    const cube = rdf.clownface({ dataset, term: this.term })
       .addOut(ns.rdf.type, ns.cube.Cube)
       .addOut(ns.cube.observationSet, this.observationSet)
       .addOut(ns.cube.observationConstraint, this.shape)
 
     cbdCopy(this.metadata, cube, { ignore: rdf.termSet([ns.cube.observationConstraint]) })
 
-    clownface({ dataset, term: this.observationSet })
+    rdf.clownface({ dataset, term: this.observationSet })
       .addOut(ns.rdf.type, ns.cube.ObservationSet)
 
     const shapeDataset = rdf.dataset()
 
-    clownface({ dataset: shapeDataset, term: this.shape })
+    rdf.clownface({ dataset: shapeDataset, term: this.shape })
       .addOut(ns.rdf.type, [ns.sh.NodeShape, ns.cube.Constraint])
       .addOut(ns.sh.closed, true)
 

--- a/packages/rdf/lib/cube/buildCubeShape/Dimension.js
+++ b/packages/rdf/lib/cube/buildCubeShape/Dimension.js
@@ -1,4 +1,3 @@
-import clownface from 'clownface'
 import rdf from '@zazuko/env'
 import { fromRdf } from 'rdf-literal'
 import cbdCopy from '../../cbdCopy.js'
@@ -79,7 +78,7 @@ class Dimension {
   toDataset({ shape }) {
     const dataset = rdf.dataset()
 
-    const ptr = clownface({ dataset }).blankNode()
+    const ptr = rdf.clownface({ dataset }).blankNode()
 
     ptr
       .addIn(ns.sh.property, shape)

--- a/packages/rdf/lib/cube/buildCubeShape/Dimension.js
+++ b/packages/rdf/lib/cube/buildCubeShape/Dimension.js
@@ -29,11 +29,12 @@ const datatypeParsers = rdf.termMap([
 ])
 
 class Dimension {
-  constructor({ metadata, predicate, object }) {
+  constructor({ metadata, predicate, object, shapeId = () => rdf.blankNode() }) {
     this.metadata = metadata
     this.predicate = predicate
     this.termType = object.termType
     this.datatype = rdf.termSet()
+    this.shapeId = shapeId
 
     if (object.datatype && datatypeParsers.has(object.datatype)) {
       const datatypeParser = datatypeParsers.get(object.datatype)
@@ -75,10 +76,11 @@ class Dimension {
     }
   }
 
-  toDataset({ shape }) {
+  toDataset({ cube, shape }) {
     const dataset = rdf.dataset()
 
-    const ptr = rdf.clownface({ dataset }).blankNode()
+    const graph = rdf.clownface({ dataset })
+    const ptr = graph.node(this.shapeId(cube, this))
 
     ptr
       .addIn(ns.sh.property, shape)

--- a/packages/rdf/lib/cube/buildCubeShape/index.js
+++ b/packages/rdf/lib/cube/buildCubeShape/index.js
@@ -27,7 +27,7 @@ function defaultShape({ term }) {
 }
 
 class CubeShapeBuilder extends Transform {
-  constructor({ excludeValuesOf, metadata, graph } = {}) {
+  constructor({ excludeValuesOf, metadata, graph, propertyShapeId } = {}) {
     super({ objectMode: true })
 
     this.options = {
@@ -37,6 +37,7 @@ class CubeShapeBuilder extends Transform {
       metadataStream: metadata,
       shape: defaultShape,
       graph,
+      propertyShapeId,
     }
 
     this.init = once(() => this._init())
@@ -75,6 +76,7 @@ class CubeShapeBuilder extends Transform {
         metadata: $rdf.clownface({ dataset: this.options.metadata, term: context.term }),
         observationSet: context.observationSet,
         shape: context.shape,
+        propertyShapeId: this.options.propertyShapeId,
       })
 
       this.options.cubes.set(context.term, context.cube)
@@ -103,8 +105,8 @@ function toNamedNode(item) {
   return typeof item === 'string' ? $rdf.namedNode(item) : item
 }
 
-function buildCubeShape({ excludeValuesOf, metadata, graph } = {}) {
-  return new CubeShapeBuilder({ excludeValuesOf, metadata, graph })
+function buildCubeShape({ excludeValuesOf, metadata, graph, propertyShapeId } = {}) {
+  return new CubeShapeBuilder({ excludeValuesOf, metadata, graph, propertyShapeId })
 }
 
 export default buildCubeShape

--- a/packages/rdf/lib/cube/buildCubeShape/index.js
+++ b/packages/rdf/lib/cube/buildCubeShape/index.js
@@ -1,4 +1,3 @@
-import clownface from 'clownface'
 import once from 'lodash/once.js'
 import $rdf from '@zazuko/env'
 import { Transform } from 'readable-stream'
@@ -62,7 +61,7 @@ class CubeShapeBuilder extends Transform {
 
     const context = {
       dataset,
-      ptr: clownface({ dataset }).has(ns.rdf.type, ns.cube.Observation),
+      ptr: $rdf.clownface({ dataset }).has(ns.rdf.type, ns.cube.Observation),
     }
 
     context.observationSet = context.ptr.in(ns.cube.observation).term
@@ -73,7 +72,7 @@ class CubeShapeBuilder extends Transform {
     if (!context.cube) {
       context.cube = new Cube({
         term: context.term,
-        metadata: clownface({ dataset: this.options.metadata, term: context.term }),
+        metadata: $rdf.clownface({ dataset: this.options.metadata, term: context.term }),
         observationSet: context.observationSet,
         shape: context.shape,
       })

--- a/packages/rdf/lib/cube/toObservation.js
+++ b/packages/rdf/lib/cube/toObservation.js
@@ -1,5 +1,4 @@
 import { URL } from 'url'
-import clownface from 'clownface'
 import rdf from '@zazuko/env'
 import { Transform } from 'readable-stream'
 import dateToId from '../dateToId.js'
@@ -26,7 +25,7 @@ function findRoot({ dataset }) {
 }
 
 function defaultObserver({ dataset, subject }) {
-  const observer = clownface({ dataset }).out(ns.cube.observedBy).term
+  const observer = rdf.clownface({ dataset }).out(ns.cube.observedBy).term
 
   if (observer) {
     return observer
@@ -58,7 +57,7 @@ function defaultObservation({ observations, subject }) {
 
 function dateByProperty(property) {
   return ({ dataset }) => {
-    return clownface({ dataset }).out(property).term
+    return rdf.clownface({ dataset }).out(property).term
   }
 }
 
@@ -67,7 +66,7 @@ function dateNow() {
 }
 
 function dateByDatatype({ dataset }) {
-  const terms = clownface({ dataset }).out().filter(ptr => ns.xsd.dateTime.equals(ptr.term.datatype)).terms
+  const terms = rdf.clownface({ dataset }).out().filter(ptr => ns.xsd.dateTime.equals(ptr.term.datatype)).terms
 
   if (terms.length === 0) {
     throw new Error('now date value found')

--- a/packages/rdf/lib/namespaces.js
+++ b/packages/rdf/lib/namespaces.js
@@ -1,13 +1,6 @@
 import $rdf from '@zazuko/env'
 
 const cube = $rdf.namespace('https://cube.link/')
-const rdf = $rdf.namespace('http://www.w3.org/1999/02/22-rdf-syntax-ns#')
-const rdfs = $rdf.namespace('http://www.w3.org/2000/01/rdf-schema#')
-const sh = $rdf.namespace('http://www.w3.org/ns/shacl#')
-const xsd = $rdf.namespace('http://www.w3.org/2001/XMLSchema#')
-const _void = $rdf.namespace('http://rdfs.org/ns/void#')
-const dcat = $rdf.namespace('http://www.w3.org/ns/dcat#')
-const schema = $rdf.namespace('http://schema.org/')
-const dcterms = $rdf.namespace('http://purl.org/dc/terms/')
+const { rdf, rdfs, sh, xsd, _void, dcat, schema, dcterms } = $rdf.ns
 
 export { cube, rdf, rdfs, sh, xsd, _void, dcat, schema, dcterms }

--- a/packages/rdf/lib/voidStats.js
+++ b/packages/rdf/lib/voidStats.js
@@ -1,4 +1,3 @@
-import clownface from 'clownface'
 import rdf from '@zazuko/env'
 import { Transform } from 'readable-stream'
 import * as ns from './namespaces.js'
@@ -60,7 +59,7 @@ class VoidStats extends Transform {
       const datasetUri = toNamedNode(this.voidDatasetUri)
       const datasetGraph = this.graph ? toNamedNode(this.graph) : undefined
 
-      const stats = clownface({
+      const stats = rdf.clownface({
         dataset: rdf.dataset(),
         graph: datasetGraph,
       })

--- a/packages/rdf/package.json
+++ b/packages/rdf/package.json
@@ -26,7 +26,6 @@
     "@rdfjs/fetch": "^3.0.0",
     "@rdfjs/formats-common": "^2.2.0",
     "@zazuko/env": "^1.1.0",
-    "clownface": "^2",
     "file-fetch": "^1.7.0",
     "is-stream": "^3.0.0",
     "lodash": "^4.17.21",

--- a/packages/rdf/test/cube/buildCubeShape.test.js
+++ b/packages/rdf/test/cube/buildCubeShape.test.js
@@ -1,6 +1,5 @@
 import { deepStrictEqual, strictEqual } from 'assert'
 import toNT from '@rdfjs/to-ntriples'
-import clownface from 'clownface'
 import { isDuplexStream as isDuplex } from 'is-stream'
 import rdf from '@zazuko/env'
 import toStream from 'rdf-dataset-ext/toStream.js'
@@ -438,7 +437,7 @@ describe('cube.buildCubeShape', () => {
   it('should merge given metadata with blank nodes to cube metadata', async () => {
     const dataset = rdf.dataset()
 
-    clownface({ dataset, term: ns.ex.cube })
+    rdf.clownface({ dataset, term: ns.ex.cube })
       .addOut(ns.ex.propertyA, null, ptr => {
         ptr
           .addOut(ns.ex.propertyB, 'Text B')
@@ -480,7 +479,7 @@ describe('cube.buildCubeShape', () => {
   it('should merge given metadata to dimension metadata', async () => {
     const dataset = rdf.dataset()
 
-    clownface({ dataset, term: ns.ex.cube })
+    rdf.clownface({ dataset, term: ns.ex.cube })
       .addOut(ns.cube.observationConstraint, shape => {
         shape.addOut(ns.sh.property, property => {
           property
@@ -489,7 +488,7 @@ describe('cube.buildCubeShape', () => {
         })
       })
 
-    clownface({ dataset, term: ns.ex.otherCube })
+    rdf.clownface({ dataset, term: ns.ex.otherCube })
       .addOut(ns.cube.observationConstraint, shape => {
         shape.addOut(ns.sh.property, property => {
           property
@@ -519,7 +518,7 @@ describe('cube.buildCubeShape', () => {
   it('should merge given metadata with blank nodes to dimension metadata', async () => {
     const dataset = rdf.dataset()
 
-    clownface({ dataset, term: ns.ex.cube })
+    rdf.clownface({ dataset, term: ns.ex.cube })
       .addOut(ns.cube.observationConstraint, shape => {
         shape.addOut(ns.sh.property, property => {
           property

--- a/packages/rdf/test/cube/toObservation.test.js
+++ b/packages/rdf/test/cube/toObservation.test.js
@@ -1,6 +1,5 @@
 import { rejects, strictEqual } from 'assert'
 import toNT from '@rdfjs/to-ntriples'
-import clownface from 'clownface'
 import getStream from 'get-stream'
 import { isDuplexStream as isDuplex } from 'is-stream'
 import rdf from '@zazuko/env'
@@ -10,11 +9,11 @@ import dateToId from '../../lib/dateToId.js'
 import * as ns from '../support/namespaces.js'
 
 function createMeasure({ term = ns.ex('topic/a') } = {}) {
-  return clownface({ dataset: rdf.dataset(), term })
+  return rdf.clownface({ dataset: rdf.dataset(), term })
 }
 
 function findObservation(result) {
-  return clownface({ dataset: rdf.dataset(result[0]) }).has(ns.rdf.type, ns.cube.Observation)
+  return rdf.clownface({ dataset: rdf.dataset(result[0]) }).has(ns.rdf.type, ns.cube.Observation)
 }
 
 describe('cube.toObservation', () => {
@@ -353,7 +352,7 @@ describe('cube.toObservation', () => {
         .dataset
 
       const transform = toObservation({
-        blacklist: [clownface({ term: ns.ex.property1 }), clownface({ term: ns.ex.property3 })],
+        blacklist: [rdf.clownface({ term: ns.ex.property1 }), rdf.clownface({ term: ns.ex.property3 })],
       })
 
       Readable.from([dataset]).pipe(transform)
@@ -391,7 +390,7 @@ describe('cube.toObservation', () => {
         .dataset
 
       const transform = toObservation({
-        dimensions: [clownface({ term: ns.ex.property1 }), clownface({ term: ns.ex.property3 })],
+        dimensions: [rdf.clownface({ term: ns.ex.property1 }), rdf.clownface({ term: ns.ex.property3 })],
       })
 
       Readable.from([dataset]).pipe(transform)

--- a/packages/rdf/test/support/createObservationsStream.js
+++ b/packages/rdf/test/support/createObservationsStream.js
@@ -1,4 +1,3 @@
-import clownface from 'clownface'
 import rdf from '@zazuko/env'
 import { Readable } from 'readable-stream'
 import * as ns from './namespaces.js'
@@ -7,7 +6,7 @@ function createObservationsStream({ observations = [{ [ns.ex.property.value]: rd
   const datasets = []
 
   observations.forEach((observation, index) => {
-    const observationPtr = clownface({
+    const observationPtr = rdf.clownface({
       dataset: rdf.dataset(),
       term: ns.ex(`cube/observation/${index + 1}`),
     })

--- a/packages/rdf/test/support/datasetStreamToClownface.js
+++ b/packages/rdf/test/support/datasetStreamToClownface.js
@@ -1,4 +1,3 @@
-import clownface from 'clownface'
 import getStream from 'get-stream'
 import rdf from '@zazuko/env'
 import addAll from 'rdf-dataset-ext/addAll.js'
@@ -6,7 +5,7 @@ import addAll from 'rdf-dataset-ext/addAll.js'
 async function datasetStreamToClownface(stream) {
   const datasets = await getStream.array(stream)
 
-  return clownface({ dataset: datasets.reduce((all, current) => addAll(all, current), rdf.dataset()) })
+  return rdf.clownface({ dataset: datasets.reduce((all, current) => addAll(all, current), rdf.dataset()) })
 }
 
 export default datasetStreamToClownface

--- a/packages/rdf/test/support/namespaces.js
+++ b/packages/rdf/test/support/namespaces.js
@@ -2,10 +2,7 @@ import $rdf from '@zazuko/env'
 
 const cube = $rdf.namespace('https://cube.link/')
 const ex = $rdf.namespace('http://example.org/')
-const rdf = $rdf.namespace('http://www.w3.org/1999/02/22-rdf-syntax-ns#')
-const schema = $rdf.namespace('http://schema.org/')
-const sh = $rdf.namespace('http://www.w3.org/ns/shacl#')
-const xsd = $rdf.namespace('http://www.w3.org/2001/XMLSchema#')
+const { rdf, schema, sh, xsd } = $rdf.ns
 
 export {
   cube,


### PR DESCRIPTION
By default cube dimensions are describe using blank node Property Shapes

This PR adds the ability to create named nodes instead