### PR TITLE
Current manifest

### DIFF
--- a/.changeset/wet-tomatoes-yawn.md
+++ b/.changeset/wet-tomatoes-yawn.md
@@ -1,0 +1,5 @@
+---
+"barnard59": minor
+---
+
+Include current project in manifest discovery

--- a/package-lock.json
+++ b/package-lock.json
@@ -12964,6 +12964,17 @@
         "node": ">=8"
       }
     },
+    "node_modules/find-up-simple": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/find-up-simple/-/find-up-simple-1.0.0.tgz",
+      "integrity": "sha512-q7Us7kcjj2VMePAa02hDAF6d+MzsdsAWEwYyOpwUtlerRBkOEPBCRZrAV4XfcSN8fHAgaD0hP7miwoay6DCprw==",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/find-yarn-workspace-root2": {
       "version": "1.2.16",
       "dev": true,
@@ -26576,6 +26587,7 @@
         "find-plugins": "^1.1.7",
         "is-graph-pointer": "^2.1.0",
         "lodash": "^4.17.21",
+        "pkg-dir": "^8.0.0",
         "readable-stream": "^3.6.0"
       },
       "bin": {
@@ -26603,6 +26615,20 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "packages/cli/node_modules/pkg-dir": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-8.0.0.tgz",
+      "integrity": "sha512-4peoBq4Wks0riS0z8741NVv+/8IiTvqnZAr8QGgtdifrtpdXbNw/FxRS1l6NFqm4EMzuS0EDqNNx4XGaz8cuyQ==",
+      "dependencies": {
+        "find-up-simple": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "packages/cli/node_modules/strip-ansi": {

--- a/packages/cli/lib/discoverManifests.js
+++ b/packages/cli/lib/discoverManifests.js
@@ -1,4 +1,5 @@
 import * as module from 'module'
+import path from 'path'
 import fs from 'fs'
 import findPlugins from 'find-plugins'
 import rdf from 'barnard59-env'
@@ -13,6 +14,15 @@ export default async function * () {
       return packagePattern.test(pkg.name) && hasManifest(pkg.name)
     },
   })
+
+  const dir = process.cwd()
+  if (hasManifest(dir)) {
+    yield {
+      name: path.basename(dir),
+      manifest: rdf.clownface({ dataset: await rdf.dataset().import(rdf.fromFile(`${dir}/manifest.ttl`)) }),
+      version: require(`${dir}/package.json`).version,
+    }
+  }
 
   for (const { pkg } of packages) {
     const { version } = require(`${pkg.name}/package.json`)

--- a/packages/cli/lib/discoverManifests.js
+++ b/packages/cli/lib/discoverManifests.js
@@ -2,6 +2,7 @@ import * as module from 'module'
 import fs from 'fs'
 import findPlugins from 'find-plugins'
 import rdf from 'barnard59-env'
+import { packageDirectory } from 'pkg-dir'
 
 const packagePattern = /^barnard59-(.+)$/
 const require = module.createRequire(import.meta.url)
@@ -14,7 +15,7 @@ export default async function * () {
     },
   })
 
-  const dir = process.cwd()
+  const dir = await packageDirectory()
   if (hasManifest(dir)) {
     const { name, version } = require(`${dir}/package.json`)
     yield {

--- a/packages/cli/lib/discoverManifests.js
+++ b/packages/cli/lib/discoverManifests.js
@@ -1,5 +1,4 @@
 import * as module from 'module'
-import path from 'path'
 import fs from 'fs'
 import findPlugins from 'find-plugins'
 import rdf from 'barnard59-env'

--- a/packages/cli/lib/discoverManifests.js
+++ b/packages/cli/lib/discoverManifests.js
@@ -17,10 +17,11 @@ export default async function * () {
 
   const dir = process.cwd()
   if (hasManifest(dir)) {
+    const { name, version } = require(`${dir}/package.json`)
     yield {
-      name: path.basename(dir),
+      name,
       manifest: rdf.clownface({ dataset: await rdf.dataset().import(rdf.fromFile(`${dir}/manifest.ttl`)) }),
-      version: require(`${dir}/package.json`).version,
+      version,
     }
   }
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -38,6 +38,7 @@
     "find-plugins": "^1.1.7",
     "is-graph-pointer": "^2.1.0",
     "lodash": "^4.17.21",
+    "pkg-dir": "^8.0.0",
     "readable-stream": "^3.6.0"
   },
   "devDependencies": {

--- a/test/e2e/definitions/foreach/csv-duplicate.ttl
+++ b/test/e2e/definitions/foreach/csv-duplicate.ttl
@@ -3,6 +3,7 @@
 @prefix p: <https://pipeline.described.at/>.
 @prefix fs: <https://barnard59.zazuko.com/operations/core/fs/> .
 @prefix base: <https://barnard59.zazuko.com/operations/base/> .
+@prefix test: <https://barnard59.zazuko.com/operations/test/> .
 
 <> a p:Pipeline, p:Readable;
   p:variables [
@@ -15,28 +16,13 @@
     p:stepList
     (
       [ fs:createReadStream("${filename}"^^code:EcmaScriptTemplateLiteral) ]
-      <parseCsv>
+      [ test:parseCsv () ]
       [ base:forEach(<subPipeline>) ]
-      <serializeJson>
+      [ test:serializeJson () ]
     )
-  ].
-
-<parseCsv> a p:Step;
-  code:implementedBy [ a code:EcmaScriptModule;
-    code:link <file:operations/parseCsv.js#default>
-  ].
-
-<serializeJson> a p:Step;
-  code:implementedBy [ a code:EcmaScriptModule;
-    code:link <file:operations/serializeJson.js#default>
   ].
 
 <subPipeline> a p:Pipeline, p:ReadableObjectMode, p:WritableObjectMode;
   p:steps [
-    p:stepList (<duplicate>)
-  ].
-
-<duplicate> a p:Step;
-  code:implementedBy [ a code:EcmaScriptModule;
-    code:link <file:operations/duplicate.js#default>
+    p:stepList ([ test:duplicate () ])
   ].

--- a/test/e2e/definitions/foreach/with-handler.ttl
+++ b/test/e2e/definitions/foreach/with-handler.ttl
@@ -4,33 +4,22 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
 @prefix base: <https://barnard59.zazuko.com/operations/base/> .
 @prefix fs: <https://barnard59.zazuko.com/operations/core/fs/> .
+@prefix test: <https://barnard59.zazuko.com/operations/test/> .
 
 <> a p:Pipeline, p:Readable;
   p:steps [
     p:stepList
     (
-      <iterateDirectory>
+      [ test:iterateDirectory ("definitions/foreach")]
       [ base:forEach ( <Print> "file" ) ]
     )
   ] .
-
-<iterateDirectory> a p:Step;
-  code:implementedBy [ a code:EcmaScriptModule;
-    code:link <file:operations/iterateDirectory.js#default>
-  ];
-  code:arguments ("definitions/foreach").
 
 <Print> a p:Pipeline, p:ReadableObjectMode;
   p:steps [
     p:stepList
     (
       [ fs:createReadStream("file"^^p:VariableName) ]
-      <getLength>
+      [ test:getLength ("_ => this.variables.get('file')"^^code:EcmaScript) ]
     )
   ].
-
-<getLength> a p:Step;
-  code:implementedBy [ a code:EcmaScriptModule;
-    code:link <file:operations/inlineTransform.js#default>
-  ];
-  code:arguments ("_ => this.variables.get('file')"^^code:EcmaScript).

--- a/test/support/manifest.ttl
+++ b/test/support/manifest.ttl
@@ -1,0 +1,30 @@
+@base <https://barnard59.zazuko.com/operations/test/> .
+@prefix code: <https://code.described.at/> .
+@prefix p: <https://pipeline.described.at/> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+<getLength> a p:Operation;
+  code:implementedBy [ a code:EcmaScriptModule;
+    code:link <file:operations/inlineTransform.js#default>
+  ].
+
+<iterateDirectory> a p:Operation;
+  code:implementedBy [ a code:EcmaScriptModule;
+    code:link <file:operations/iterateDirectory.js#default>
+  ].
+
+
+<parseCsv> a p:Operation;
+  code:implementedBy [ a code:EcmaScriptModule;
+    code:link <file:operations/parseCsv.js#default>
+  ].
+
+<serializeJson> a p:Operation;
+  code:implementedBy [ a code:EcmaScriptModule;
+    code:link <file:operations/serializeJson.js#default>
+  ].
+
+<duplicate> a p:Operation;
+  code:implementedBy [ a code:EcmaScriptModule;
+    code:link <file:operations/duplicate.js#default>
+  ].


### PR DESCRIPTION
The current project is included in manifest discovery, enabling simplified syntax also for operations defined in the manifest of the current project (as exemplified in the e2e tests). Maybe this is even more useful to enable package-specific CLI commands defined in the current project's manifest.