### PR TITLE
feat: context should be read-only

### DIFF
--- a/.changeset/eight-ants-brake.md
+++ b/.changeset/eight-ants-brake.md
@@ -1,0 +1,5 @@
+---
+"barnard59-core": major
+---
+
+Freeze pipeline context object to prevent accidental modifications

--- a/packages/core/lib/factory/pipeline.ts
+++ b/packages/core/lib/factory/pipeline.ts
@@ -85,7 +85,7 @@ function createPipeline(maybePtr: { term?: Term; dataset?: DatasetCore }, init: 
     context.createPipeline = (ptr, { context, ...args } = {}) => createPipeline(ptr, { ...defaults, ...args })
 
     pipeline.variables = variables
-    pipeline.context = context
+    pipeline.context = Object.freeze(context)
 
     for (const stepPtr of ptr.out(context.env.ns.p.steps).out(context.env.ns.p.stepList).list()!) {
       if (stepPtr.has(context.env.ns.rdf.type, context.env.ns.p.Pipeline).terms.length > 0) {

--- a/packages/core/test/Pipeline.test.js
+++ b/packages/core/test/Pipeline.test.js
@@ -37,7 +37,7 @@ describe('Pipeline', () => {
 
     await finished(pipeline.stream)
 
-    strictEqual(pipeline.context.content.toString(), 'test')
+    strictEqual(pipeline.context.variables.get('input').toString(), 'test')
   })
 
   it('should support nested pipelines', async () => {

--- a/packages/core/test/support/definitions/write.ttl
+++ b/packages/core/test/support/definitions/write.ttl
@@ -11,8 +11,8 @@
   code:implementedBy [ a code:EcmaScriptModule;
     code:link <node:barnard59-base#map>
   ];
-  code:arguments ("""input => {
-    this.content = input
+  code:arguments ("""function (input) {
+    this.variables.set('input', input)
 
     return input
   }"""^^code:EcmaScript).


### PR DESCRIPTION
I think we should prevent modification of pipeline context. Implementors should use `variables` or, in the future (#110), locals

Even though it'd not be a a legitimate use of barnard59, there was actually a test which directly modifies the context. In case anyone else did that, I consider this a breaking change