### PR TITLE
Hotfix oom

### DIFF
--- a/.changeset/fresh-deers-switch.md
+++ b/.changeset/fresh-deers-switch.md
@@ -2,4 +2,4 @@
 "barnard59-shacl": patch
 ---
 
-reduce memory pressure
+prevent potential memory leaks by creating a fresh validator for each chunk

--- a/.changeset/fresh-deers-switch.md
+++ b/.changeset/fresh-deers-switch.md
@@ -1,0 +1,5 @@
+---
+"barnard59-shacl": patch
+---
+
+reduce memory pressure

--- a/.changeset/stale-feet-report.md
+++ b/.changeset/stale-feet-report.md
@@ -1,0 +1,5 @@
+---
+"barnard59-rdf": patch
+---
+
+fix manifest entry for splitDataset (bySubject and byType)

--- a/packages/rdf/manifest.ttl
+++ b/packages/rdf/manifest.ttl
@@ -82,7 +82,7 @@
   code:implementedBy
     [
       a code:EcmaScript ;
-      code:link <node:rdf-stream-to-dataset-stream/byPredicate.js> ;
+      code:link <node:rdf-stream-to-dataset-stream/bySubject.js> ;
     ]
 .
 
@@ -93,6 +93,6 @@
   code:implementedBy
     [
       a code:EcmaScript ;
-      code:link <node:rdf-stream-to-dataset-stream/byPredicate.js> ;
+      code:link <node:rdf-stream-to-dataset-stream/byType.js> ;
     ]
 .


### PR DESCRIPTION
both changes are needed to avoid out of memory errors. 
The error in manifest would lead to a single, huge chunk. 
The reuse of the validator instance maybe is worth further investigation to understand why it apparently leaks memory.
But creating a new validator instance for each chunk is sufficient here