### PR TITLE
Prioritise explicitly set variables

### DIFF
--- a/.changeset/good-readers-thank.md
+++ b/.changeset/good-readers-thank.md
@@ -1,0 +1,5 @@
+---
+"barnard59": patch
+---
+
+`--variable` option should have precedence over environments variables imported with `--variable-all` (closes #74)

--- a/packages/cli/lib/cli/options.js
+++ b/packages/cli/lib/cli/options.js
@@ -17,7 +17,9 @@ export function combine({ variable: commandVars, ...options }) {
 
   if (variableAll) {
     for (const [key, value] of Object.entries(process.env)) {
-      variables.set(key, value)
+      if (!variables.has(key)) {
+        variables.set(key, value)
+      }
     }
   }
 

--- a/packages/cli/test/barnard59.test.js
+++ b/packages/cli/test/barnard59.test.js
@@ -115,24 +115,25 @@ describe('barnard59', function () {
     })
 
     describe('variable-all', () => {
-      it('should import all environment variables', () => {
-        const pipelineFile = filenamePipelineDefinition('simple')
-        const command = `abc=123 def=456 ${barnard59} run --pipeline=http://example.org/pipeline/ -vv ${pipelineFile} --variable-all`
+      [
+        ['abc=123 def=456', '--variable-all', '', 'should import all environment variables'],
+        ['abc=123 def=456', '', '--variable-all', 'should import all environment variables'],
+        ['abc=123 def=123', '--variable-all --variable def=456', '', 'should override single variable'],
+        ['abc=123 def=123', '--variable-all', '--variable def=456', 'should override single variable'],
+        ['abc=123 def=123', '--variable def=456', '--variable-all', 'should override single variable'],
+        ['abc=123 def=123', '', '--variable-all --variable def=456', 'should override single variable'],
+      ].forEach(([env, optionsBefore, optionsAfter, title]) => {
+        context(`${optionsBefore} run ${optionsAfter}`, () => {
+          it(title, () => {
+            const pipelineFile = filenamePipelineDefinition('simple')
+            const command = `${env} ${barnard59} ${optionsBefore} run --pipeline=http://example.org/pipeline/ -vv ${pipelineFile} ${optionsAfter}`
 
-        const result = stripAnsi(shell.exec(command, { silent: true }).stderr)
+            const result = stripAnsi(shell.exec(command, { silent: true }).stderr)
 
-        expect(result).to.match(/info:.+abc: 123/)
-        expect(result).to.match(/verbose:.+def: 456/)
-      })
-
-      it('should import all environment variables before command', () => {
-        const pipelineFile = filenamePipelineDefinition('simple')
-        const command = `abc=123 def=456 ${barnard59} --variable-all run --pipeline=http://example.org/pipeline/ -vv ${pipelineFile}`
-
-        const result = stripAnsi(shell.exec(command, { silent: true }).stderr)
-
-        expect(result).to.match(/info:.+abc: 123/)
-        expect(result).to.match(/verbose:.+def: 456/)
+            expect(result).to.match(/info:.+abc: 123/)
+            expect(result).to.match(/verbose:.+def: 456/)
+          })
+        })
       })
     })
   })


### PR DESCRIPTION
Currently, if a pipeline was started form a script like

```
export FOO=bar
npx barnard59 --variable-all --variable FOO=baz run ...
```

The value of `FOO` would be that from the environment. I find this behaviour a bug, thus a `patch` bump in the changset. On the other hand, existing pipelines may unwittingly rely on it. One might argue it would thus justify a `major` bump, again.