### PR TITLE
pipeline to check class constraints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 *.tgz
 *.d.ts
 *.js.map
+temp

--- a/packages/cube/lib/classConstraint.js
+++ b/packages/cube/lib/classConstraint.js
@@ -1,0 +1,55 @@
+import { Readable, Duplex } from 'stream'
+import { sort, compareOn, createStore } from 'external-merge-sort'
+import through2 from 'through2'
+
+export function choose(quad) {
+  const predicate = this.env.namedNode(this.variables.get('path'))
+  const classNode = this.env.namedNode(this.variables.get('class'))
+  if (predicate.equals(quad.predicate)) {
+    return this.env.quad(quad.subject, quad.predicate, quad.object, quad.object)
+  }
+  if (classNode.equals(quad.object) && this.env.ns.rdf.type.equals(quad.predicate)) {
+    return this.env.quad(quad.subject, quad.predicate, quad.object, quad.subject)
+  }
+}
+
+export function sortByGraph(sortChunkSize) {
+  const write = async (chunk, filename) => {
+    await this.env.toFile(Readable.from(chunk), filename)
+    return this.env.fromFile(filename)
+  }
+
+  const typeFirstComparer = compareOn(quad => this.env.ns.rdf.type.equals(quad.predicate) ? 0 : 1)
+
+  const comparer = (x, y) => {
+    if (x.graph.value < y.graph.value) {
+      return -1
+    }
+    if (x.graph.value > y.graph.value) {
+      return 1
+    }
+    return typeFirstComparer(x, y)
+  }
+
+  const store = createStore(write, '.nt')
+  const maxSize = Number(sortChunkSize)
+
+  const stream = Duplex.from(iterable => sort(iterable, { comparer, store, maxSize }))
+  stream.on('finish', store.dispose)
+  stream.on('error', store.dispose)
+  return stream
+}
+
+export function check() {
+  const a = this.env.ns.rdf.type
+  const t = through2.obj(function (chunk, _encoding, callback) {
+    if (chunk.predicate.equals(a)) {
+      t.current = chunk
+    } else if (!chunk.object.equals(t.current?.subject)) {
+      this.push(chunk)
+    }
+    callback()
+  })
+
+  return t
+}

--- a/packages/cube/manifest.ttl
+++ b/packages/cube/manifest.ttl
@@ -48,3 +48,10 @@
   rdfs:label "Validate input observations against cube constraint" ;
   b59:source "barnard59-cube/pipeline/check-observations.ttl" ;
 .
+
+<command/cube/check-class>
+  a b59:CliCommand ;
+  b59:command "check-class" ;
+  rdfs:label "Validate input observations against a class constraint" ;
+  b59:source "barnard59-cube/pipeline/check-class.ttl" ;
+.

--- a/packages/cube/pipeline/check-class.ttl
+++ b/packages/cube/pipeline/check-class.ttl
@@ -1,0 +1,70 @@
+@prefix code: <https://code.described.at/> .
+@prefix p: <https://pipeline.described.at/> .
+@prefix shacl: <https://barnard59.zazuko.com/operations/shacl/> .
+@prefix base: <https://barnard59.zazuko.com/operations/base/> .
+@prefix getDataset: <https://barnard59.zazuko.com/operations/rdf/getDataset> .
+@prefix splitDataset: <https://barnard59.zazuko.com/operations/rdf/splitDataset/> .
+@prefix n3: <https://barnard59.zazuko.com/operations/formats/n3/> .
+@prefix ntriples: <https://barnard59.zazuko.com/operations/formats/ntriples/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+@base <http://barnard59.zazuko.com/pipeline/cube-validation/> .
+
+_:path a p:Variable ;
+  p:name "path" ;
+  rdfs:label "property whose range is class".
+
+_:class a p:Variable ;
+  p:name "class" ;
+  rdfs:label "range class of path".
+
+_:maxViolations a p:Variable ;
+  p:name "maxViolations" ;
+  rdfs:label "max number of violations" ;
+  p:value 500 ;
+.
+
+_:sortChunkSize a p:Variable ;
+  p:name "sortChunkSize" ;
+  rdfs:label "sort chunk size" ;
+  p:value 100000 ;
+.
+
+<check-class> a p:Pipeline , p:Readable;
+  p:variables [ p:variable _:path, _:class, _:maxViolations, _:sortChunkSize ] ;
+  p:steps
+    [
+      p:stepList
+      (
+        [ base:stdin () ]
+        [ n3:parse () ]
+        _:choose
+        _:sortByGraph
+        _:check
+        [ base:limit ("maxViolations"^^p:VariableName)]
+        [ ntriples:serialize () ]
+      )
+    ]
+.
+
+_:choose base:map (
+  [
+    a code:EcmaScriptModule ;
+    code:link <file:../lib/classConstraint.js#choose>
+  ] 
+) .
+
+_:sortByGraph a p:Step ;
+  code:implementedBy [ a code:EcmaScriptModule ;
+    code:link <file:../lib/classConstraint.js#sortByGraph>
+  ] ;
+  code:arguments ("sortChunkSize"^^p:VariableName)
+.
+
+_:check a p:Step ;
+  code:implementedBy [ a code:EcmaScriptModule ;
+    code:link <file:../lib/classConstraint.js#check>
+  ] 
+.
+


### PR DESCRIPTION
an experiment (still a draft) to overcome the issue described in https://github.com/zazuko/barnard59/pull/236.

The new `check-class`  command can check for a class constraint like the one in https://github.com/zazuko/cube-link/blob/main/constraint.ttl
```bash
cat cube.ttl | npx b59 cube check-class \
    --path http://ns.bergnet.org/dark-horse#room \
    --class http://schema.org/Place
```
Of course https://github.com/zazuko/cube-link/blob/main/cube.ttl is small enough and can be checked all at once disabling batching, the command is meant for cases with a huge number of observations.

The main idea is to scan the data filtering only relevant quads and sorting them such that each type declaration is followed by the quads referencing it. The checking [step](https://github.com/zazuko/barnard59/blob/a934e9ea77d0b3d3a9271aebfb9560deb061a8a9/packages/cube/lib/classConstraint.js#L43) can then easily spot the invalid quads (those missing the corresponding type declaration)
