### PR TITLE
feat: simpler logging, remote parsing

### DIFF
--- a/.changeset/orange-actors-peel.md
+++ b/.changeset/orange-actors-peel.md
@@ -1,0 +1,5 @@
+---
+"barnard59-core": patch
+---
+
+Hook default logger to `anylogger` to simplify 3rd party lib logging

--- a/.changeset/seven-snakes-divide.md
+++ b/.changeset/seven-snakes-divide.md
@@ -1,0 +1,5 @@
+---
+"barnard59-rdf": patch
+---
+
+`rdf:open` would not apply resource URL as base when parsing

--- a/package-lock.json
+++ b/package-lock.json
@@ -26518,6 +26518,7 @@
       "license": "MIT",
       "dependencies": {
         "@opentelemetry/api": "^1.0.1",
+        "anylogger": "^1.0.11",
         "duplex-to": "^1.0.1",
         "duplexify": "^4.1.1",
         "is-graph-pointer": "^2.1.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -22,6 +22,7 @@
   "homepage": "https://github.com/zazuko/barnard59",
   "dependencies": {
     "@opentelemetry/api": "^1.0.1",
+    "anylogger": "^1.0.11",
     "duplex-to": "^1.0.1",
     "duplexify": "^4.1.1",
     "is-graph-pointer": "^2.1.0",

--- a/packages/rdf/open.js
+++ b/packages/rdf/open.js
@@ -8,19 +8,17 @@ export default async function (pathOrUri, mediaTypeOverride) {
   }
 
   const response = await this.env.fetch(url)
-  let contentType
+  let parserStream
   if (mediaTypeOverride) {
-    contentType = mediaTypeOverride
-  } else {
-    contentType = response.headers.get('content-type')
-    if (!contentType) {
-      throw new Error(`No content-type header found for ${url}`)
-    }
-  }
+    parserStream = this.env.formats.parsers.import(mediaTypeOverride, response.body, {
+      baseIRI: response.url,
+    })
 
-  const parserStream = this.env.formats.parsers.import(contentType, response.body)
-  if (!parserStream) {
-    throw new Error(`No parser found for ${contentType}`)
+    if (!parserStream) {
+      throw new Error(`No parser found for ${mediaTypeOverride}`)
+    }
+  } else {
+    parserStream = await response.quadStream()
   }
 
   return parserStream

--- a/packages/rdf/test/open.test.js
+++ b/packages/rdf/test/open.test.js
@@ -23,16 +23,10 @@ describe('open', function () {
 
   it('should load from remote URL', async () => {
     // given
+    const quadStream = sinon.stub().returns('foo')
     const env = {
-      formats: {
-        parsers: {
-          import: sinon.stub().returns('foo'),
-        },
-      },
-      fetch: async () => new Response('', {
-        headers: {
-          'Content-Type': 'text/turtle',
-        },
+      fetch: async () => ({
+        quadStream,
       }),
     }
 
@@ -49,7 +43,7 @@ describe('open', function () {
 
       // then
       expect(quad).to.eq('foo')
-      expect(env.formats.parsers.import).to.have.been.calledWith('text/turtle', sinon.match.any)
+      expect(quadStream).to.have.been.called
     })
   })
 


### PR DESCRIPTION
1. I added `anylogger` hook to winston so that libraries can transparently log with `anylogger` and that gets forwarded to our logging setup (added some logs to `rdf-transform-graph-imports`)
2. Fixed `rdf:open` where it did not parse with the request URL as base. I only applied that to the path with override because `@rdfjs/fetch` already does that. Thus, by default the environment is used (also supports JSON-LD context discovery)