### PR TITLE
fix: find barnard59.js when running global installation

### DIFF
--- a/.changeset/hot-coats-admire.md
+++ b/.changeset/hot-coats-admire.md
@@ -1,0 +1,5 @@
+---
+"barnard59": patch
+---
+
+Fix: running from global installation did not work

--- a/packages/cli/bin/barnard59.sh
+++ b/packages/cli/bin/barnard59.sh
@@ -1,13 +1,21 @@
 #!/usr/bin/env bash
 
-SCRIPT_PATH=$(dirname "$0")
+# find local barnard59
+barnard59=$(node -e "console.log(require.resolve('barnard59/bin/barnard59.js'))" 2> /dev/null)
+
+if [ -z "$barnard59" ]
+then
+  # find global barnard59
+  NODE_PATH=$(npm config get prefix)
+  barnard59=$(node -e "console.log(require('path').join('$NODE_PATH', '/lib/node_modules/barnard59/bin/barnard59.js'))")
+fi
 
 # if ts-node exists in path
 if command -v ts-node &> /dev/null
 then
   # use ts-node
-  node --loader ts-node/esm/transpile-only --no-warnings "$SCRIPT_PATH"/../barnard59/bin/barnard59.js "$@"
+  node --loader ts-node/esm/transpile-only --no-warnings "$barnard59" "$@"
 else
   # use plain node
-  node "$SCRIPT_PATH"/../barnard59/bin/barnard59.js "$@"
+  node "$barnard59" "$@"
 fi


### PR DESCRIPTION
I struggled a little with getting the b59 script to work when installed globally. Problem is that the path relation between bin and node_modules is different in global installation. Thus, I resorted to trying `require.resolve` and the fall back to finding the current node path from npm