### PR TITLE
fix: b59 run would fail on relative pipeline path

### DIFF
--- a/.changeset/shiny-snakes-love.md
+++ b/.changeset/shiny-snakes-love.md
@@ -1,0 +1,5 @@
+---
+"barnard59-test-e2e": minor
+---
+
+Make the e2e tests reflect real CLI usage more closely by setting `basePath` to be the actual pipeline path

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -84,6 +84,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
+      - run: npm ci
       - run: npx barnard59 run test/e2e/definitions/file-loader.ttl
       - run: npx barnard59 run test/e2e/definitions/foreach/with-handler.ttl
       - run: npx barnard59 run test/e2e/definitions/foreach/with-variable.ttl --variable pattern="test/e2e/definitions/foreach/*"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -79,6 +79,19 @@ jobs:
       - run: npm ci
       - run: npm run lint
 
+  smoke-test-cli:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v3
+      - run: npx barnard59 run test/e2e/definitions/file-loader.ttl
+      - run: npx barnard59 run test/e2e/definitions/foreach/with-handler.ttl
+      - run: npx barnard59 run test/e2e/definitions/foreach/with-variable.ttl --variable pattern="test/e2e/definitions/foreach/*"
+      - run: npx barnard59 run test/e2e/definitions/foreach/csv-duplicate.ttl --variable filename=test/e2e/data/test.csv
+      - run: npx barnard59 run test/e2e/definitions/world-clock/async.ttl
+      - run: npx barnard59 run test/e2e/definitions/world-clock/file.ttl
+      - run: npx barnard59 run test/e2e/definitions/world-clock/node.ttl
+
   global-installation:
     runs-on: ubuntu-latest
     steps:

--- a/packages/cli/lib/pipeline.js
+++ b/packages/cli/lib/pipeline.js
@@ -109,7 +109,7 @@ async function fileToDataset(filename) {
  */
 export async function parse(filename, iri, { logger } = {}) {
   const dataset = await fileToDataset(filename)
-  const ptr = findPipeline(await desugar(dataset, { logger, pipelinePath: filename }), iri)
+  const ptr = findPipeline(await desugar(dataset, { logger, pipelinePath: resolve(filename) }), iri)
 
   return {
     basePath: resolve(dirname(filename)),

--- a/packages/cli/test/runner.test.js
+++ b/packages/cli/test/runner.test.js
@@ -8,7 +8,7 @@ const loadPipelineDefinition = pipelineDefinitionLoader(import.meta.url)
 
 describe('run', () => {
   it('should emit an error if an error in the pipeline occurs', async () => {
-    const ptr = await loadPipelineDefinition('error')
+    const { ptr } = await loadPipelineDefinition('error')
     const run = await runner(ptr, env, {
       outputStream: process.stdout,
       basePath: resolve('test'),

--- a/packages/cli/test/simplify.test.js
+++ b/packages/cli/test/simplify.test.js
@@ -17,9 +17,9 @@ const knownOperations = rdf.termMap([
 ])
 
 const check = async name => {
-  const pipeline = await loadPipelineDefinition(name, { desugar: false })
+  const { ptr } = await loadPipelineDefinition(name, { desugar: false })
 
-  const result = await desugar(pipeline.dataset, { knownOperations })
+  const result = await desugar(ptr.dataset, { knownOperations })
 
   approvals.verify(dirname, name, result.toCanonical())
 }

--- a/packages/core/test/Pipeline.test.js
+++ b/packages/core/test/Pipeline.test.js
@@ -20,7 +20,7 @@ describe('Pipeline', () => {
   })
 
   it('should process the given pipeline definition', async () => {
-    const ptr = await loadPipelineDefinition('read')
+    const { ptr } = await loadPipelineDefinition('read')
 
     const pipeline = createPipeline(ptr, { env, basePath: resolve('test') })
 
@@ -30,7 +30,7 @@ describe('Pipeline', () => {
   })
 
   it('should support writable pipelines', async () => {
-    const ptr = await loadPipelineDefinition('write')
+    const { ptr } = await loadPipelineDefinition('write')
 
     const pipeline = createPipeline(ptr, { env, basePath: resolve('test') })
 
@@ -42,7 +42,7 @@ describe('Pipeline', () => {
   })
 
   it('should support nested pipelines', async () => {
-    const ptr = await loadPipelineDefinition('nested')
+    const { ptr } = await loadPipelineDefinition('nested')
 
     const pipeline = createPipeline(ptr, { env, basePath: resolve('test') })
 
@@ -52,7 +52,7 @@ describe('Pipeline', () => {
   })
 
   it('should emit error when nested pipeline step errors immediately', async () => {
-    const ptr = await loadPipelineDefinition('nestedErrorBeforeInit')
+    const { ptr } = await loadPipelineDefinition('nestedErrorBeforeInit')
 
     const pipeline = createPipeline(ptr, { env, basePath: resolve('test') })
 
@@ -62,7 +62,7 @@ describe('Pipeline', () => {
   })
 
   it('should support nested writable pipelines', async () => {
-    const ptr = await loadPipelineDefinition('nested-write')
+    const { ptr } = await loadPipelineDefinition('nested-write')
     const result = []
 
     const pipeline = createPipeline(ptr, {
@@ -77,7 +77,7 @@ describe('Pipeline', () => {
   })
 
   it('should assign the pipeline stream to the .stream property', async () => {
-    const ptr = await loadPipelineDefinition('nested')
+    const { ptr } = await loadPipelineDefinition('nested')
 
     const pipeline = createPipeline(ptr, { env, basePath: resolve('test') })
 
@@ -85,7 +85,7 @@ describe('Pipeline', () => {
   })
 
   it('should assign the pipeline to the .pipeline property of the stream', async () => {
-    const ptr = await loadPipelineDefinition('nested')
+    const { ptr } = await loadPipelineDefinition('nested')
 
     const pipeline = createPipeline(ptr, { env, basePath: resolve('test') })
 
@@ -93,7 +93,7 @@ describe('Pipeline', () => {
   })
 
   it('should have a basePath string property', async () => {
-    const ptr = await loadPipelineDefinition('read')
+    const { ptr } = await loadPipelineDefinition('read')
 
     const pipeline = createPipeline(ptr, { env, basePath: resolve('test') })
 
@@ -101,7 +101,7 @@ describe('Pipeline', () => {
   })
 
   it('should have a context object property', async () => {
-    const ptr = await loadPipelineDefinition('read')
+    const { ptr } = await loadPipelineDefinition('read')
 
     const pipeline = createPipeline(ptr, { env, basePath: resolve('test') })
 
@@ -109,7 +109,7 @@ describe('Pipeline', () => {
   })
 
   it('should emit an error if the Pipeline contains no steps', async () => {
-    const ptr = await loadPipelineDefinition('empty')
+    const { ptr } = await loadPipelineDefinition('empty')
 
     const pipeline = createPipeline(ptr, { env, basePath: resolve('test') })
 
@@ -119,7 +119,7 @@ describe('Pipeline', () => {
   })
 
   it('should have a ptr clownface property', async () => {
-    const ptr = await loadPipelineDefinition('read')
+    const { ptr } = await loadPipelineDefinition('read')
 
     const pipeline = createPipeline(ptr, { env, basePath: resolve('test') })
 
@@ -129,7 +129,7 @@ describe('Pipeline', () => {
   })
 
   it('should have a ptr variables Map property', async () => {
-    const ptr = await loadPipelineDefinition('read')
+    const { ptr } = await loadPipelineDefinition('read')
 
     const pipeline = createPipeline(ptr, { env, basePath: resolve('test') })
 
@@ -137,7 +137,7 @@ describe('Pipeline', () => {
   })
 
   it('should emit an error if an operation returns an invalid stream', async () => {
-    const ptr = await loadPipelineDefinition('step-invalid')
+    const { ptr } = await loadPipelineDefinition('step-invalid')
 
     const pipeline = createPipeline(ptr, { env, basePath: resolve('test') })
 
@@ -147,7 +147,7 @@ describe('Pipeline', () => {
   })
 
   it('should emit an error if an operation rejects with error', async () => {
-    const ptr = await loadPipelineDefinition('step-operation-error')
+    const { ptr } = await loadPipelineDefinition('step-operation-error')
 
     const pipeline = createPipeline(ptr, { env, basePath: resolve('test') })
 
@@ -157,7 +157,7 @@ describe('Pipeline', () => {
   })
 
   it('should emit step stream errors', async () => {
-    const ptr = await loadPipelineDefinition('step-stream-error')
+    const { ptr } = await loadPipelineDefinition('step-stream-error')
 
     const pipeline = createPipeline(ptr, { env, basePath: resolve('test') })
 
@@ -167,7 +167,7 @@ describe('Pipeline', () => {
   })
 
   it('should catch and emit step stream errors', async () => {
-    const ptr = await loadPipelineDefinition('step-stream-throw')
+    const { ptr } = await loadPipelineDefinition('step-stream-throw')
 
     const pipeline = createPipeline(ptr, { env, basePath: resolve('test') })
 
@@ -178,7 +178,7 @@ describe('Pipeline', () => {
 
   describe('plain Pipeline', () => {
     it('should emit an end event', async () => {
-      const ptr = await loadPipelineDefinition('plain')
+      const { ptr } = await loadPipelineDefinition('plain')
 
       const pipeline = createPipeline(ptr, { env, basePath: resolve('test') })
 
@@ -192,7 +192,7 @@ describe('Pipeline', () => {
 
   describe('readable Pipeline', () => {
     it('should emit an end event', async () => {
-      const ptr = await loadPipelineDefinition('read')
+      const { ptr } = await loadPipelineDefinition('read')
 
       const pipeline = createPipeline(ptr, { env, basePath: resolve('test') })
 
@@ -204,7 +204,7 @@ describe('Pipeline', () => {
     })
 
     it('should emit an error if the last step doesn\'t have a readable interface', async () => {
-      const ptr = await loadPipelineDefinition('read-step-not-read')
+      const { ptr } = await loadPipelineDefinition('read-step-not-read')
 
       const pipeline = createPipeline(ptr, { env, basePath: resolve('test') })
 
@@ -216,7 +216,7 @@ describe('Pipeline', () => {
 
   describe('writeable Pipeline', () => {
     it('should emit an finish event', async () => {
-      const ptr = await loadPipelineDefinition('write')
+      const { ptr } = await loadPipelineDefinition('write')
 
       const pipeline = createPipeline(ptr, { env, basePath: resolve('test') })
 

--- a/packages/core/test/factory/arguments.test.js
+++ b/packages/core/test/factory/arguments.test.js
@@ -15,7 +15,7 @@ describe('factory/arguments', () => {
   })
 
   it('should build key-value pair arguments', async () => {
-    const definition = await loadPipelineDefinition('arguments')
+    const { ptr: definition } = await loadPipelineDefinition('arguments')
     const ptr = [...definition.node(ns.ex.keyValues).out(ns.p.steps).out(ns.p.stepList).list()][0]
 
     const args = await createArguments(ptr, {
@@ -27,7 +27,7 @@ describe('factory/arguments', () => {
   })
 
   it('should build key-value pair arguments with undefined variable', async () => {
-    const definition = await loadPipelineDefinition('arguments')
+    const { ptr: definition } = await loadPipelineDefinition('arguments')
     const ptr = [...definition.node(ns.ex.keyValueMissingVar).out(ns.p.steps).out(ns.p.stepList).list()][0]
     const variables = new VariableMap()
     variables.set('a', undefined, { optional: true })
@@ -42,7 +42,7 @@ describe('factory/arguments', () => {
   })
 
   it('should build list arguments', async () => {
-    const definition = await loadPipelineDefinition('arguments')
+    const { ptr: definition } = await loadPipelineDefinition('arguments')
     const ptr = [...definition.node(ns.ex.list).out(ns.p.steps).out(ns.p.stepList).list()][0]
 
     const args = await createArguments(ptr, {
@@ -54,7 +54,7 @@ describe('factory/arguments', () => {
   })
 
   it('should build list arguments with undefined variable', async () => {
-    const definition = await loadPipelineDefinition('arguments')
+    const { ptr: definition } = await loadPipelineDefinition('arguments')
     const ptr = [...definition.node(ns.ex.listMissingVar).out(ns.p.steps).out(ns.p.stepList).list()][0]
     const variables = new VariableMap()
     variables.set('a', undefined, { optional: true })
@@ -69,7 +69,7 @@ describe('factory/arguments', () => {
   })
 
   it('should forward variables to the loader', async () => {
-    const definition = await loadPipelineDefinition('arguments')
+    const { ptr: definition } = await loadPipelineDefinition('arguments')
     const ptr = [...definition.node(ns.ex.variable).out(ns.p.steps).out(ns.p.stepList).list()][0]
 
     const args = await createArguments(ptr, {

--- a/packages/core/test/factory/operation.test.js
+++ b/packages/core/test/factory/operation.test.js
@@ -16,7 +16,7 @@ describe('factory/operation', () => {
   })
 
   it('should load the given operation', async () => {
-    const definition = await loadPipelineDefinition('plain')
+    const { ptr: definition } = await loadPipelineDefinition('plain')
     const ptr = [...definition.node(ns.ex('')).out(ns.p.steps).out(ns.p.stepList).list()][0].out(ns.code.implementedBy)
 
     const operation = await createOperation(ptr, {

--- a/packages/core/test/factory/pipeline.test.js
+++ b/packages/core/test/factory/pipeline.test.js
@@ -17,15 +17,15 @@ describe('factory/pipeline', () => {
   })
 
   it('should return a Pipeline object', async () => {
-    const definition = await loadPipelineDefinition('plain')
+    const { ptr } = await loadPipelineDefinition('plain')
 
-    const pipeline = createPipeline(definition, { env, basePath: resolve('test') })
+    const pipeline = createPipeline(ptr, { env, basePath: resolve('test') })
 
     strictEqual(pipeline instanceof Pipeline, true)
   })
 
   it('should load the given pipeline from a plain graph pointer', async () => {
-    const definition = await loadPipelineDefinition('plain')
+    const { ptr: definition } = await loadPipelineDefinition('plain')
     const ptr = { dataset: definition.dataset, term: definition.term }
 
     const pipeline = createPipeline(ptr, { env, basePath: resolve('test') })
@@ -35,15 +35,15 @@ describe('factory/pipeline', () => {
   })
 
   it('should throw an error if the term property of the graph pointer is missing', async () => {
-    const ptr = (await loadPipelineDefinition('read')).any()
+    const { ptr: graph } = await loadPipelineDefinition('read')
 
     throws(() => {
-      createPipeline(ptr, { env, basePath: resolve('test') })
+      createPipeline(graph.any(), { env, basePath: resolve('test') })
     })
   })
 
   it('should throw an error if the dataset property of the graph pointer is missing', async () => {
-    const ptr = (await loadPipelineDefinition('read'))
+    const { ptr } = (await loadPipelineDefinition('read'))
 
     throws(() => {
       createPipeline({ term: ptr.term }, { env, basePath: resolve('test') })
@@ -52,7 +52,7 @@ describe('factory/pipeline', () => {
 
   it('should use the given basePath', async () => {
     const basePath = resolve('test')
-    const ptr = await loadPipelineDefinition('read')
+    const { ptr } = await loadPipelineDefinition('read')
 
     const pipeline = createPipeline(ptr, { env, basePath })
 
@@ -61,7 +61,7 @@ describe('factory/pipeline', () => {
 
   it('should use the given context', async () => {
     const context = { abc: 'def', env }
-    const ptr = await loadPipelineDefinition('read')
+    const { ptr } = await loadPipelineDefinition('read')
 
     const pipeline = createPipeline(ptr, { env, basePath: resolve('test'), context })
     await getStream(pipeline.stream)
@@ -70,7 +70,7 @@ describe('factory/pipeline', () => {
   })
 
   it('should create a pipeline with readable interface matching the rdf:type', async () => {
-    const ptr = await loadPipelineDefinition('read')
+    const { ptr } = await loadPipelineDefinition('read')
 
     const pipeline = createPipeline(ptr, { env, basePath: resolve('test') })
 
@@ -79,7 +79,7 @@ describe('factory/pipeline', () => {
   })
 
   it('should create a pipeline with readable object mode interface matching the rdf:type', async () => {
-    const ptr = await loadPipelineDefinition('read-object-mode')
+    const { ptr } = await loadPipelineDefinition('read-object-mode')
 
     const pipeline = createPipeline(ptr, { env, basePath: resolve('test') })
 
@@ -87,7 +87,7 @@ describe('factory/pipeline', () => {
   })
 
   it('should create a pipeline with writable interface matching the rdf:type', async () => {
-    const ptr = await loadPipelineDefinition('write')
+    const { ptr } = await loadPipelineDefinition('write')
 
     const pipeline = createPipeline(ptr, { env, basePath: resolve('test') })
 
@@ -96,7 +96,7 @@ describe('factory/pipeline', () => {
   })
 
   it('should create a pipeline with writable object mode interface matching the rdf:type', async () => {
-    const ptr = await loadPipelineDefinition('write-object-mode')
+    const { ptr } = await loadPipelineDefinition('write-object-mode')
 
     const pipeline = createPipeline(ptr, { env, basePath: resolve('test') })
 
@@ -104,9 +104,9 @@ describe('factory/pipeline', () => {
   })
 
   it('should attach createPipeline to the context', async () => {
-    const definition = await loadPipelineDefinition('plain')
+    const { ptr } = await loadPipelineDefinition('plain')
 
-    const pipeline = createPipeline(definition, { env, basePath: resolve('test') })
+    const pipeline = createPipeline(ptr, { env, basePath: resolve('test') })
     await pipeline.init()
 
     strictEqual(typeof pipeline.context.createPipeline, 'function')
@@ -114,7 +114,7 @@ describe('factory/pipeline', () => {
 
   it('should log variables', async () => {
     // given
-    const definition = await loadPipelineDefinition('nested')
+    const { ptr } = await loadPipelineDefinition('nested')
     const logger = {
       debug: sinon.spy(),
       info: sinon.spy(),
@@ -124,7 +124,7 @@ describe('factory/pipeline', () => {
     }
 
     // when
-    const pipeline = createPipeline(definition, {
+    const pipeline = createPipeline(ptr, {
       env,
       basePath: resolve('test'),
       logger,

--- a/packages/core/test/factory/step.test.js
+++ b/packages/core/test/factory/step.test.js
@@ -18,7 +18,7 @@ describe('factory/step', () => {
   })
 
   it('should load the given step', async () => {
-    const definition = await loadPipelineDefinition('plain')
+    const { ptr: definition } = await loadPipelineDefinition('plain')
     const ptr = [...definition.node(ns.ex('')).out(ns.p.steps).out(ns.p.stepList).list()][0]
 
     const step = await createStep(ptr, {
@@ -32,7 +32,7 @@ describe('factory/step', () => {
   })
 
   it('should forward errors thrown by the loader', async () => {
-    const definition = await loadPipelineDefinition('step-operation-missing-error')
+    const { ptr: definition } = await loadPipelineDefinition('step-operation-missing-error')
     const ptr = [...definition.node(ns.ex('')).out(ns.p.steps).out(ns.p.stepList).list()][0]
 
     await rejects(async () => {
@@ -51,7 +51,7 @@ describe('factory/step', () => {
   })
 
   it('should attach step to the context', async () => {
-    const definition = await loadPipelineDefinition('step-ptr')
+    const { ptr: definition } = await loadPipelineDefinition('step-ptr')
     const ptr = [...definition.node(ns.ex('')).out(ns.p.steps).out(ns.p.stepList).list()][0]
 
     const step = await createStep(ptr, {

--- a/packages/core/test/factory/variables.test.js
+++ b/packages/core/test/factory/variables.test.js
@@ -12,7 +12,7 @@ const context = { env }
 
 describe('factory/variables', () => {
   it('should return a VariableMap', async () => {
-    const definition = await loadPipelineDefinition('plain')
+    const { ptr: definition } = await loadPipelineDefinition('plain')
     const ptr = definition.node(ns.ex('')).out(ns.p.variables)
 
     const variables = await createVariables(ptr, {
@@ -25,7 +25,7 @@ describe('factory/variables', () => {
   })
 
   it('should load "required" annotation', async () => {
-    const definition = await loadPipelineDefinition('variables')
+    const { ptr: definition } = await loadPipelineDefinition('variables')
     const ptr = definition.node(ns.ex.inline).out(ns.p.variables)
 
     const variables = await createVariables(ptr, {
@@ -38,7 +38,7 @@ describe('factory/variables', () => {
   })
 
   it('should load the given inline variables', async () => {
-    const definition = await loadPipelineDefinition('variables')
+    const { ptr: definition } = await loadPipelineDefinition('variables')
     const ptr = definition.node(ns.ex.inline).out(ns.p.variables)
 
     const variables = await createVariables(ptr, {
@@ -51,7 +51,7 @@ describe('factory/variables', () => {
   })
 
   it('should load the given variables sets', async () => {
-    const definition = await loadPipelineDefinition('variables')
+    const { ptr: definition } = await loadPipelineDefinition('variables')
     const ptr = definition.node(ns.ex.multiset).out(ns.p.variables)
 
     const variables = await createVariables(ptr, {

--- a/packages/core/test/loader/pipeline.test.js
+++ b/packages/core/test/loader/pipeline.test.js
@@ -11,7 +11,7 @@ const context = { env: rdf }
 describe('loader/pipeline', () => {
   it('should use the given variables', async () => {
     const basePath = resolve('test')
-    const ptr = await loadPipelineDefinition('plain')
+    const { ptr } = await loadPipelineDefinition('plain')
 
     const variables = new Map([
       ['foo', 'bar'],

--- a/test/e2e/definitions/file-loader.ttl
+++ b/test/e2e/definitions/file-loader.ttl
@@ -23,6 +23,6 @@ _:openSelf
     """^^code:EcmaScript ;
   code:arguments
     (
-      "definitions/file-loader.ttl"^^p:FileContents
+      "file-loader.ttl"^^p:FileContents
     )
 .

--- a/test/e2e/definitions/foreach/with-handler.ttl
+++ b/test/e2e/definitions/foreach/with-handler.ttl
@@ -10,7 +10,7 @@
   p:steps [
     p:stepList
     (
-      [ test:iterateDirectory ("definitions/foreach")]
+      [ test:iterateDirectory (".")]
       [ base:forEach ( <Print> "file" ) ]
     )
   ] .

--- a/test/e2e/definitions/foreach/with-variable.ttl
+++ b/test/e2e/definitions/foreach/with-variable.ttl
@@ -1,29 +1,41 @@
-@base <http://example.org/pipeline/>.
-@prefix code: <https://code.described.at/>.
-@prefix p: <https://pipeline.described.at/>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@base <http://example.org/pipeline/> .
+@prefix code: <https://code.described.at/> .
+@prefix p: <https://pipeline.described.at/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix base: <https://barnard59.zazuko.com/operations/base/> .
 
-<> a p:Pipeline, p:ReadableObjectMode;
-  p:variables [
-    p:variable [ a p:Variable;
-      p:name "root";
-      p:value "/root/"
-    ]
-  ];
-  p:steps [
-    p:stepList (<glob> [ base:forEach( <printFilename> ) ])
-  ] .
+<> a p:Pipeline, p:ReadableObjectMode ;
+  p:variables
+    [
+      p:variable
+        [
+          a p:Variable ;
+          p:name "root" ;
+          p:value "/root/"
+        ] ;
+      p:variable
+        [
+          a p:Variable ;
+          p:name "pattern" ;
+          p:value "definitions/foreach/*"
+        ]
+    ] ;
+  p:steps
+    [
+      p:stepList ( <glob> [ base:forEach ( <printFilename> ) ] )
+    ] .
 
-<glob> base:glob [
-  code:name "pattern";
-  code:value "definitions/foreach/*"
-].
+<glob> base:glob
+    [
+      code:name "pattern" ;
+      code:value "pattern"^^p:VariableName
+    ] .
 
-<printFilename> a p:Pipeline, p:WritableObjectMode, p:ReadableObjectMode;
-  p:steps [
-    p:stepList
-    (
-      [ base:map("filename => this.variables.get('root') + filename"^^code:EcmaScript) ]
-    )
-  ].
+<printFilename> a p:Pipeline, p:WritableObjectMode, p:ReadableObjectMode ;
+  p:steps
+    [
+      p:stepList
+        (
+          [ base:map ( "filename => this.variables.get('root') + filename"^^code:EcmaScript ) ]
+        )
+    ] .

--- a/test/e2e/forEach.e2e.test.js
+++ b/test/e2e/forEach.e2e.test.js
@@ -1,5 +1,4 @@
-import { deepStrictEqual, strictEqual } from 'assert'
-import { resolve } from 'path'
+import { deepStrictEqual, strictEqual } from 'node:assert'
 import { createPipeline } from 'barnard59-core'
 import getStream from 'get-stream'
 import { pipelineDefinitionLoader } from 'barnard59-test-support/loadPipelineDefinition.js'
@@ -9,8 +8,8 @@ const loadPipelineDefinition = pipelineDefinitionLoader(import.meta.url, 'defini
 
 describe('forEach', () => {
   it('should execute the example correctly', async () => {
-    const ptr = await loadPipelineDefinition('foreach/csv-duplicate')
-    const pipeline = createPipeline(ptr, { env, basePath: resolve('.') })
+    const { ptr, basePath } = await loadPipelineDefinition('foreach/csv-duplicate')
+    const pipeline = createPipeline(ptr, { env, basePath })
 
     const out = JSON.parse(await getStream(pipeline.stream))
 
@@ -22,8 +21,8 @@ describe('forEach', () => {
   * added during pipeline execution of a forEach step
   * */
   it('should preserve variables set during forEach execution', async () => {
-    const ptr = await loadPipelineDefinition('foreach/with-handler')
-    const pipeline = createPipeline(ptr, { env, basePath: resolve('.') })
+    const { ptr, basePath } = await loadPipelineDefinition('foreach/with-handler')
+    const pipeline = createPipeline(ptr, { env, basePath })
 
     const out = await getStream.array(pipeline.stream)
 
@@ -32,8 +31,8 @@ describe('forEach', () => {
   })
 
   it('should be able to access variables from higher scopes', async () => {
-    const ptr = await loadPipelineDefinition('foreach/with-variable')
-    const pipeline = createPipeline(ptr, { env, basePath: resolve('.') })
+    const { ptr, basePath } = await loadPipelineDefinition('foreach/with-variable')
+    const pipeline = createPipeline(ptr, { env, basePath })
 
     const out = await getStream.array(pipeline.stream)
 

--- a/test/e2e/operations/iterateDirectory.js
+++ b/test/e2e/operations/iterateDirectory.js
@@ -14,6 +14,11 @@ class FileIterator extends Readable {
     const directory = resolve(basePath, dirName)
 
     readdir(directory, (e, files) => {
+      if (e) {
+        this.emit('error', e)
+        return
+      }
+
       files.forEach(file => {
         this.push(resolve(directory, file))
       })

--- a/test/e2e/pipeline.e2e.test.js
+++ b/test/e2e/pipeline.e2e.test.js
@@ -1,4 +1,4 @@
-import { deepStrictEqual } from 'assert'
+import { deepStrictEqual } from 'node:assert'
 import getStream from 'get-stream'
 import nock from 'nock'
 import createPipeline from 'barnard59-core/lib/factory/pipeline.js'
@@ -33,8 +33,8 @@ describe('Pipeline', () => {
   })
 
   it('should load code using node: scheme', async () => {
-    const ptr = await loadPipelineDefinition('world-clock/node')
-    const pipeline = await createPipeline(ptr, { env })
+    const { ptr, basePath } = await loadPipelineDefinition('world-clock/node')
+    const pipeline = await createPipeline(ptr, { env, basePath })
 
     const out = await getStream(pipeline.stream)
 
@@ -42,8 +42,8 @@ describe('Pipeline', () => {
   })
 
   it('should load code using file: scheme', async () => {
-    const ptr = await loadPipelineDefinition('world-clock/file')
-    const pipeline = await createPipeline(ptr, { env, basePath: process.cwd() })
+    const { ptr, basePath } = await loadPipelineDefinition('world-clock/file')
+    const pipeline = await createPipeline(ptr, { env, basePath })
 
     const out = await getStream(pipeline.stream)
 
@@ -51,13 +51,13 @@ describe('Pipeline', () => {
   })
 
   it('should load code using async loaders', async () => {
-    const ptr = await loadPipelineDefinition('world-clock/async')
+    const { ptr, basePath } = await loadPipelineDefinition('world-clock/async')
     const loaderRegistry = defaultLoaderRegistry(env)
 
     promisedEcmaScriptLoader.register(loaderRegistry)
     promisedUrlLoader.register(loaderRegistry)
 
-    const pipeline = await createPipeline(ptr, { env, loaderRegistry })
+    const pipeline = await createPipeline(ptr, { env, loaderRegistry, basePath })
 
     const out = await getStream(pipeline.stream)
 
@@ -66,10 +66,10 @@ describe('Pipeline', () => {
 
   it('should load file contents using loader', async () => {
     // given
-    const ptr = await loadPipelineDefinition('file-loader')
+    const { ptr, basePath } = await loadPipelineDefinition('file-loader')
     const pipeline = await createPipeline(ptr, {
       env,
-      basePath: process.cwd(),
+      basePath,
     })
 
     // when
@@ -82,10 +82,10 @@ describe('Pipeline', () => {
 
   it('should be set to fail from sub-pipeline', async () => {
     // given
-    const ptr = await loadPipelineDefinition('sub-pipeline-error')
+    const { ptr, basePath } = await loadPipelineDefinition('sub-pipeline-error')
     const pipeline = await createPipeline(ptr, {
       env,
-      basePath: process.cwd(),
+      basePath,
     })
 
     // when
@@ -99,10 +99,10 @@ describe('Pipeline', () => {
 
   it('works with async generator steps', async () => {
     // given
-    const ptr = await loadPipelineDefinition('limit-offset')
+    const { ptr, basePath } = await loadPipelineDefinition('limit-offset')
     const pipeline = await createPipeline(ptr, {
       env,
-      basePath: process.cwd(),
+      basePath,
     })
 
     // when

--- a/test/support/loadPipelineDefinition.js
+++ b/test/support/loadPipelineDefinition.js
@@ -1,5 +1,5 @@
-import { resolve } from 'path'
-import * as url from 'url'
+import { resolve, dirname } from 'node:path'
+import * as url from 'node:url'
 import rdf from '@zazuko/env'
 import fromFile from 'rdf-utils-fs/fromFile.js'
 import namespace from '@rdfjs/namespace'
@@ -20,6 +20,9 @@ export function pipelineDefinitionLoader(baseUrl, path = 'support/definitions') 
       dataset = await desugarDefinition(dataset, { logger, pipelinePath: filename })
     }
 
-    return rdf.clownface({ dataset, term })
+    return {
+      ptr: rdf.clownface({ dataset, term }),
+      basePath: dirname(filename),
+    }
   }
 }

--- a/test/support/manifest.ttl
+++ b/test/support/manifest.ttl
@@ -5,26 +5,26 @@
 
 <getLength> a p:Operation;
   code:implementedBy [ a code:EcmaScriptModule;
-    code:link <file:operations/inlineTransform.js#default>
+    code:link <node:barnard59-test-e2e/operations/inlineTransform.js#default>
   ].
 
 <iterateDirectory> a p:Operation;
   code:implementedBy [ a code:EcmaScriptModule;
-    code:link <file:operations/iterateDirectory.js#default>
+    code:link <node:barnard59-test-e2e/operations/iterateDirectory.js#default>
   ].
 
 
 <parseCsv> a p:Operation;
   code:implementedBy [ a code:EcmaScriptModule;
-    code:link <file:operations/parseCsv.js#default>
+    code:link <node:barnard59-test-e2e/operations/parseCsv.js#default>
   ].
 
 <serializeJson> a p:Operation;
   code:implementedBy [ a code:EcmaScriptModule;
-    code:link <file:operations/serializeJson.js#default>
+    code:link <node:barnard59-test-e2e/operations/serializeJson.js#default>
   ].
 
 <duplicate> a p:Operation;
   code:implementedBy [ a code:EcmaScriptModule;
-    code:link <file:operations/duplicate.js#default>
+    code:link <node:barnard59-test-e2e/operations/duplicate.js#default>
   ].


### PR DESCRIPTION
I added a CI job which runs the test e2e pipelines from the b59 CLI. This revealed the regression where pipeline path was no longer properly resolved against working dir

Also need to update some test infrastructure