### PR TITLE
optimize human readable report

### DIFF
--- a/.changeset/eleven-deers-rescue.md
+++ b/.changeset/eleven-deers-rescue.md
@@ -1,0 +1,5 @@
+---
+"barnard59-shacl": patch
+---
+
+barnard59-shacl: rephrase messages in human-readable report

--- a/packages/shacl/lib/report.js
+++ b/packages/shacl/lib/report.js
@@ -9,7 +9,7 @@ function validationResultToString(result) {
   const sourceConstraintComponent = result.sourceConstraintComponent.value.split('#')[1]
   const sourceShape = termToNt(result.sourceShape)
 
-  return `${severity} of ${sourceConstraintComponent}: "${message}" with path ${path} at focus node ${focusNode} (source: ${sourceShape})`
+  return `${severity}: "${message}" at focus node ${focusNode} with path ${path} (${sourceConstraintComponent} of source: ${sourceShape})`
 }
 
 function includeNestedResult(result) {


### PR DESCRIPTION
@giacomociti  the current form of report messages are hard to interpret even for me.
therefore here a proposal to make human readable report easier to read and understand 😄 

example:
```
Violation: "Cube must have exactly one scaleType: qudt:IntervalScale, qudt:NominalScale, qudt:RatioScale, or qudt:OrdinalScale" at focus node <https://agriculture.ld.admin.ch/foag/cube/MilkDairyProducts/Consumption_Price_Month/shape> with path <http://www.w3.org/ns/shacl#property> (OrConstraintComponent of source: _:b89_b650)
```