### PR TITLE
fix(types): correct for nodeNext

### DIFF
--- a/.changeset/soft-geese-lie.md
+++ b/.changeset/soft-geese-lie.md
@@ -1,0 +1,6 @@
+---
+"barnard59-shacl": patch
+"barnard59-env": patch
+---
+
+Accurate imports to work with `moduleResolution=NodeNext`

--- a/package-lock.json
+++ b/package-lock.json
@@ -26932,7 +26932,7 @@
     },
     "packages/base": {
       "name": "barnard59-base",
-      "version": "2.4.1",
+      "version": "2.4.2",
       "license": "MIT",
       "dependencies": {
         "@opentelemetry/api": "^1.0.1",
@@ -27124,9 +27124,9 @@
         "@types/lodash": "^4.14.202",
         "@types/readable-stream": "^4.0.10",
         "approvals": "^6.2.2",
-        "barnard59-base": "^2.4.1",
+        "barnard59-base": "^2.4.2",
         "barnard59-formats": "^2.1.0",
-        "barnard59-graph-store": "^5.1.2",
+        "barnard59-graph-store": "^6.0.0",
         "barnard59-http": "^2.0.0",
         "barnard59-shell": "^0.1.0",
         "barnard59-test-support": "^0.0.3",
@@ -27348,15 +27348,15 @@
     },
     "packages/cube": {
       "name": "barnard59-cube",
-      "version": "1.4.1",
+      "version": "1.4.3",
       "license": "MIT",
       "dependencies": {
-        "barnard59-base": "^2.4.0",
+        "barnard59-base": "^2.4.2",
         "barnard59-formats": "^2.0.0",
         "barnard59-http": "^2.0.0",
         "barnard59-rdf": "^3.4.0",
-        "barnard59-shacl": "^1.4.2",
-        "barnard59-sparql": "^2.2.0",
+        "barnard59-shacl": "^1.4.4",
+        "barnard59-sparql": "^2.3.0",
         "external-merge-sort": "^0.1.4",
         "lodash": "^4.17.21",
         "rdf-literal": "^1.3.0",
@@ -27593,10 +27593,10 @@
     },
     "packages/graph-store": {
       "name": "barnard59-graph-store",
-      "version": "5.1.2",
+      "version": "6.0.0",
       "license": "MIT",
       "dependencies": {
-        "barnard59-base": "^2.4.1",
+        "barnard59-base": "^2.4.2",
         "barnard59-rdf": "^3.0.0",
         "duplex-to": "^1.0.0",
         "onetime": "^6.0.0",
@@ -27869,12 +27869,12 @@
     },
     "packages/shacl": {
       "name": "barnard59-shacl",
-      "version": "1.4.3",
+      "version": "1.4.4",
       "license": "MIT",
       "dependencies": {
         "@rdfjs/fetch": "^3.0.0",
         "@rdfjs/to-ntriples": "^3.0.0",
-        "barnard59-base": "^2.4.1",
+        "barnard59-base": "^2.4.2",
         "barnard59-formats": "^2.1.0",
         "barnard59-rdf": "^3.4.0",
         "is-stream": "^3.0.0",
@@ -27915,7 +27915,7 @@
     },
     "packages/sparql": {
       "name": "barnard59-sparql",
-      "version": "2.2.0",
+      "version": "2.3.0",
       "license": "MIT",
       "dependencies": {
         "duplex-to": "^1.0.1",

--- a/packages/env/lib/Constants.ts
+++ b/packages/env/lib/Constants.ts
@@ -1,6 +1,6 @@
 import type { Literal, DataFactory } from '@rdfjs/types'
 import type { Environment } from '@rdfjs/environment/Environment.js'
-import type { NsBuildersFactory } from '@tpluscode/rdf-ns-builders/Factory.js'
+import type NsBuildersFactory from '@tpluscode/rdf-ns-builders'
 
 export default class ConstantsFactory {
   FALSE!: Literal

--- a/packages/env/lib/Namespaces.ts
+++ b/packages/env/lib/Namespaces.ts
@@ -1,4 +1,4 @@
-import type { NsBuildersFactory } from '@tpluscode/rdf-ns-builders/Factory.js'
+import type NsBuildersFactory from '@tpluscode/rdf-ns-builders'
 import type { Environment } from '@rdfjs/environment/Environment.js'
 import type { NamespaceFactory } from '@rdfjs/namespace/Factory.js'
 import * as Builders from '@zazuko/vocabulary-extras-builders'

--- a/packages/shacl/lib/errors.js
+++ b/packages/shacl/lib/errors.js
@@ -1,5 +1,5 @@
 /**
- * @param {import('rdf-validate-shacl/src/validation-report').ValidationReport} report
+ * @param {import('rdf-validate-shacl/src/validation-report.js').ValidationReport} report
  */
 function buildErrorMessage(report) {
   return JSON.stringify(report.results.map(x => {
@@ -23,7 +23,7 @@ function buildErrorMessage(report) {
 
 export class ValidationError extends Error {
   /**
-   * @param {import('rdf-validate-shacl/src/validation-report').ValidationReport} report
+   * @param {import('rdf-validate-shacl/src/validation-report.js').ValidationReport} report
    * @param {import('@rdfjs/types').DatasetCore} shapesGraph
    * @param {import('@rdfjs/types').DatasetCore} dataGraph
    */


### PR DESCRIPTION
It's not yet possible to switch the entire project to NodeNext but at least I changed these two imports which cause problems downstream where that module resoultion is used