### PR TITLE
Fix 304

### DIFF
--- a/.changeset/brave-news-fail.md
+++ b/.changeset/brave-news-fail.md
@@ -1,0 +1,5 @@
+---
+"barnard59-cube": patch
+---
+
+Preferably create a single `sh:in` when building a cube shape

--- a/packages/cube/lib/cube/buildCubeShape/constraintBuilder/DimensionConstraintsBuilder.js
+++ b/packages/cube/lib/cube/buildCubeShape/constraintBuilder/DimensionConstraintsBuilder.js
@@ -2,6 +2,7 @@ import { DatatypeConstraintBuilder } from './DatatypeConstraintBuilder.js'
 import { CompositeConstraintBuilder } from './CompositeConstraintBuilder.js'
 import { RangeConstraintBuilder } from './RangeConstraintBuilder.js'
 import { ValuesConstraintBuilder } from './ValuesConstraintBuilder.js'
+import { NodeKindConstraintBuilder } from './NodeKindConstraintBuilder.js'
 
 export class DimensionConstraintsBuilder {
   constructor({ rdf, datatypeParsers, inListMaxSize }) {
@@ -37,7 +38,9 @@ export class DimensionConstraintsBuilder {
     if (this.valuesBuilder) {
       this.valuesBuilder.add(object)
     } else {
-      this.valuesBuilder = new ValuesConstraintBuilder(this.rdf, this.inListMaxSize)
+      this.valuesBuilder = new CompositeConstraintBuilder(
+        new ValuesConstraintBuilder(this.rdf, this.inListMaxSize),
+        new NodeKindConstraintBuilder(this.rdf))
       this.valuesBuilder.add(object)
     }
   }

--- a/packages/cube/lib/cube/buildCubeShape/constraintBuilder/DimensionConstraintsBuilder.js
+++ b/packages/cube/lib/cube/buildCubeShape/constraintBuilder/DimensionConstraintsBuilder.js
@@ -51,11 +51,6 @@ export class DimensionConstraintsBuilder {
   }
 
   build(ptr) {
-    if (this.valuesBuilder?.message) {
-      ptr.addOut(this.rdf.ns.sh.description, this.valuesBuilder.message)
-      return
-    }
-
     const builders = [...this.builders.values()]
     if (this.valuesBuilder) {
       builders.push(this.valuesBuilder)

--- a/packages/cube/lib/cube/buildCubeShape/constraintBuilder/ValuesConstraintBuilder.js
+++ b/packages/cube/lib/cube/buildCubeShape/constraintBuilder/ValuesConstraintBuilder.js
@@ -17,6 +17,10 @@ export class ValuesConstraintBuilder {
   }
 
   build(ptr) {
+    if (this.message) {
+      ptr.addOut(this.sh.description, this.message)
+      return
+    }
     if (this.enabled && this.values.size > 0) {
       ptr.addList(this.sh.in, this.values)
     }

--- a/packages/cube/test/cube/buildCubeShape.test.js
+++ b/packages/cube/test/cube/buildCubeShape.test.js
@@ -1,4 +1,4 @@
-import { strictEqual } from 'assert'
+import { deepEqual, strictEqual } from 'assert'
 import toNT from '@rdfjs/to-ntriples'
 import { isDuplexStream as isDuplex } from 'is-stream'
 import rdf from 'barnard59-env'
@@ -553,6 +553,33 @@ describe('cube.buildCubeShape', () => {
     const undefinedType = disjuncts.find(x => x.out(ns.sh.datatype).term.equals(ns.cube.Undefined))
     checkRange(integer, two, five)
     checkValues(undefinedType, undefinedValue)
+  })
+
+  it('should merge sh:in constraints if there are strings and named nodes', async () => {
+    const stringValue = rdf.literal('a', ns.xsd.string)
+
+    const input = createObservationsStream({
+      observations: [{
+        [ex.property.value]: stringValue,
+      }, {
+        [ex.property.value]: ex.valueA,
+      }],
+    })
+    const transform = buildCubeShape()
+
+    input.pipe(transform)
+
+    const result = await datasetStreamToClownface(transform)
+
+    const propertyShape = result.has(ns.sh.path, ex.property)
+
+    const disjuncts = [...propertyShape.out(ns.sh.or).list()]
+    const nodeKind = disjuncts.find(x => x.has(ns.sh.nodeKind).term)
+    const datatype = disjuncts.find(x => x.has(ns.sh.datatype).term)
+
+    deepEqual(nodeKind.out(ns.sh.nodeKind).term, ns.sh.IRI)
+    deepEqual(datatype.out(ns.sh.datatype).term, ns.xsd.string)
+    checkValues(propertyShape, stringValue, ex.valueA)
   })
 
   it('should create no range constraints on parsing error', async () => {

--- a/packages/cube/test/cube/constraintBuilder/DimensionConstraintsBuilder.test.js
+++ b/packages/cube/test/cube/constraintBuilder/DimensionConstraintsBuilder.test.js
@@ -3,7 +3,7 @@ import { fromRdf } from 'rdf-literal'
 import { DimensionConstraintsBuilder } from '../../../lib/cube/buildCubeShape/constraintBuilder/DimensionConstraintsBuilder.js'
 import { buildShape, conforms, notConforms } from './support.js'
 
-const { xsd } = rdf.ns
+const { xsd, cube } = rdf.ns
 
 const datatypeParsers = rdf.termMap([
   [xsd.integer, fromRdf],
@@ -20,6 +20,7 @@ describe('DimensionConstraintsBuilder', () => {
   const two = rdf.literal('2', xsd.integer)
   const three = rdf.literal('3', xsd.integer)
   const four = rdf.literal('4', xsd.integer)
+  const cubeUndefined = rdf.literal('', cube.Undefined)
 
   context('built from two named nodes', () => {
     const builder = new DimensionConstraintsBuilder({ rdf, datatypeParsers })
@@ -37,7 +38,7 @@ describe('DimensionConstraintsBuilder', () => {
     const validator = buildShape(builder, namedNode1, namedNode2)
     const assertConforms = conforms.bind(null, validator)
     const assertNotConforms = notConforms.bind(null, validator)
-    it.only('all named nodes conform', () => assertConforms(namedNode1, namedNode2, namedNode3))
+    it('all named nodes conform', () => assertConforms(namedNode1, namedNode2, namedNode3))
     it('a string literal does not conform', () => assertNotConforms(string1))
     it('an integer literal does not conform', () => assertNotConforms(one))
   })
@@ -73,7 +74,7 @@ describe('DimensionConstraintsBuilder', () => {
     it('a string literal does not conform', () => assertNotConforms(string1))
     it('a named node does not conform', () => assertNotConforms(namedNode1))
   })
-  context('built two named nodes, two strings and two integers', () => {
+  context('built from two named nodes, two strings and two integers', () => {
     const builder = new DimensionConstraintsBuilder({ rdf, datatypeParsers })
     const validator = buildShape(builder, namedNode1, namedNode2, string1, string2, one, three)
     const assertConforms = conforms.bind(null, validator)
@@ -86,5 +87,24 @@ describe('DimensionConstraintsBuilder', () => {
     it('the two integers conform', () => assertConforms(one, three))
     it('an integer in between conforms', () => assertConforms(two))
     it('an integer outside the range does not conform', () => assertNotConforms(four))
+  })
+  context('built from a string and a cube:Undefined', () => {
+    const builder = new DimensionConstraintsBuilder({ rdf, datatypeParsers })
+    const validator = buildShape(builder, string1, cubeUndefined)
+    const assertConforms = conforms.bind(null, validator)
+    const assertNotConforms = notConforms.bind(null, validator)
+
+    it('the two values conform', () => assertConforms(string1, cubeUndefined))
+    it('another string does not conform', () => assertNotConforms(string2))
+  })
+  context('built from a string and a named node', () => {
+    const builder = new DimensionConstraintsBuilder({ rdf, datatypeParsers })
+    const validator = buildShape(builder, string1, namedNode1)
+    const assertConforms = conforms.bind(null, validator)
+    const assertNotConforms = notConforms.bind(null, validator)
+
+    it('the two values conform', () => assertConforms(string1, namedNode1))
+    it('another string does not conform', () => assertNotConforms(string2))
+    it('another named node does not conform', () => assertNotConforms(namedNode2))
   })
 })

--- a/packages/cube/test/cube/constraintBuilder/DimensionConstraintsBuilder.test.js
+++ b/packages/cube/test/cube/constraintBuilder/DimensionConstraintsBuilder.test.js
@@ -36,7 +36,10 @@ describe('DimensionConstraintsBuilder', () => {
     const builder = new DimensionConstraintsBuilder({ rdf, datatypeParsers, inListMaxSize: 1 })
     const validator = buildShape(builder, namedNode1, namedNode2)
     const assertConforms = conforms.bind(null, validator)
-    it('everything conforms', () => assertConforms(namedNode1, namedNode2, namedNode3, string1, one))
+    const assertNotConforms = notConforms.bind(null, validator)
+    it.only('all named nodes conform', () => assertConforms(namedNode1, namedNode2, namedNode3))
+    it('a string literal does not conform', () => assertNotConforms(string1))
+    it('an integer literal does not conform', () => assertNotConforms(one))
   })
   context('built from two strings', () => {
     const builder = new DimensionConstraintsBuilder({ rdf, datatypeParsers })

--- a/packages/cube/test/cube/constraintBuilder/DimensionConstraintsBuilder.test.js
+++ b/packages/cube/test/cube/constraintBuilder/DimensionConstraintsBuilder.test.js
@@ -33,15 +33,18 @@ describe('DimensionConstraintsBuilder', () => {
     it('a string literal does not conform', () => assertNotConforms(string1))
     it('an integer literal does not conform', () => assertNotConforms(one))
   })
+
   context('built from too many distinct named nodes', () => {
     const builder = new DimensionConstraintsBuilder({ rdf, datatypeParsers, inListMaxSize: 1 })
     const validator = buildShape(builder, namedNode1, namedNode2)
     const assertConforms = conforms.bind(null, validator)
     const assertNotConforms = notConforms.bind(null, validator)
+
     it('all named nodes conform', () => assertConforms(namedNode1, namedNode2, namedNode3))
     it('a string literal does not conform', () => assertNotConforms(string1))
     it('an integer literal does not conform', () => assertNotConforms(one))
   })
+
   context('built from two strings', () => {
     const builder = new DimensionConstraintsBuilder({ rdf, datatypeParsers })
     const validator = buildShape(builder, string1, string2)
@@ -53,15 +56,18 @@ describe('DimensionConstraintsBuilder', () => {
     it('a named node does not conform', () => assertNotConforms(namedNode1))
     it('an integer literal does not conform', () => assertNotConforms(one))
   })
+
   context('built from too many distinct strings', () => {
     const builder = new DimensionConstraintsBuilder({ rdf, datatypeParsers, inListMaxSize: 1 })
     const validator = buildShape(builder, string1, string2)
     const assertConforms = conforms.bind(null, validator)
     const assertNotConforms = notConforms.bind(null, validator)
+
     it('every string conforms', () => assertConforms(string1, string2, string3))
     it('an integer literal does not conform', () => assertNotConforms(one))
     it('a named node does not conform', () => assertNotConforms(namedNode1))
   })
+
   context('built from two integers', () => {
     const builder = new DimensionConstraintsBuilder({ rdf, datatypeParsers })
     const validator = buildShape(builder, one, three)
@@ -74,6 +80,7 @@ describe('DimensionConstraintsBuilder', () => {
     it('a string literal does not conform', () => assertNotConforms(string1))
     it('a named node does not conform', () => assertNotConforms(namedNode1))
   })
+
   context('built from two named nodes, two strings and two integers', () => {
     const builder = new DimensionConstraintsBuilder({ rdf, datatypeParsers })
     const validator = buildShape(builder, namedNode1, namedNode2, string1, string2, one, three)
@@ -88,6 +95,7 @@ describe('DimensionConstraintsBuilder', () => {
     it('an integer in between conforms', () => assertConforms(two))
     it('an integer outside the range does not conform', () => assertNotConforms(four))
   })
+
   context('built from a string and a cube:Undefined', () => {
     const builder = new DimensionConstraintsBuilder({ rdf, datatypeParsers })
     const validator = buildShape(builder, string1, cubeUndefined)
@@ -97,6 +105,7 @@ describe('DimensionConstraintsBuilder', () => {
     it('the two values conform', () => assertConforms(string1, cubeUndefined))
     it('another string does not conform', () => assertNotConforms(string2))
   })
+
   context('built from a string and a named node', () => {
     const builder = new DimensionConstraintsBuilder({ rdf, datatypeParsers })
     const validator = buildShape(builder, string1, namedNode1)


### PR DESCRIPTION
should address #304.  As discussed, the main idea is, in case there is a `sh:or` with all the alternatives having their own `sh:in`, to merge all the values into a single, top-level `sh:in` constraint.